### PR TITLE
Bump version to 0.3.0-SNAPSHOT

### DIFF
--- a/build-tools/build-common/pom.xml
+++ b/build-tools/build-common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>build-tools</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>build-common</artifactId>

--- a/build-tools/build-common/pom.xml
+++ b/build-tools/build-common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>build-tools</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>build-common</artifactId>

--- a/build-tools/config-generator/pom.xml
+++ b/build-tools/config-generator/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>build-tools</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>config-generator</artifactId>

--- a/build-tools/config-generator/pom.xml
+++ b/build-tools/config-generator/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>build-tools</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>config-generator</artifactId>

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>skywalking-graalvm-distro</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>build-tools</artifactId>

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>skywalking-graalvm-distro</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>build-tools</artifactId>

--- a/build-tools/precompiler/pom.xml
+++ b/build-tools/precompiler/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>build-tools</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>precompiler</artifactId>

--- a/build-tools/precompiler/pom.xml
+++ b/build-tools/precompiler/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>build-tools</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>precompiler</artifactId>

--- a/oap-graalvm-native/pom.xml
+++ b/oap-graalvm-native/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>skywalking-graalvm-distro</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>oap-graalvm-native</artifactId>

--- a/oap-graalvm-native/pom.xml
+++ b/oap-graalvm-native/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>skywalking-graalvm-distro</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>oap-graalvm-native</artifactId>

--- a/oap-graalvm-server/pom.xml
+++ b/oap-graalvm-server/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>skywalking-graalvm-distro</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>oap-graalvm-server</artifactId>

--- a/oap-graalvm-server/pom.xml
+++ b/oap-graalvm-server/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>skywalking-graalvm-distro</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>oap-graalvm-server</artifactId>

--- a/oap-libs-for-graalvm/agent-analyzer-for-graalvm/pom.xml
+++ b/oap-libs-for-graalvm/agent-analyzer-for-graalvm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>oap-libs-for-graalvm</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>agent-analyzer-for-graalvm</artifactId>

--- a/oap-libs-for-graalvm/agent-analyzer-for-graalvm/pom.xml
+++ b/oap-libs-for-graalvm/agent-analyzer-for-graalvm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>oap-libs-for-graalvm</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>agent-analyzer-for-graalvm</artifactId>

--- a/oap-libs-for-graalvm/aws-firehose-receiver-for-graalvm/pom.xml
+++ b/oap-libs-for-graalvm/aws-firehose-receiver-for-graalvm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>oap-libs-for-graalvm</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aws-firehose-receiver-for-graalvm</artifactId>

--- a/oap-libs-for-graalvm/aws-firehose-receiver-for-graalvm/pom.xml
+++ b/oap-libs-for-graalvm/aws-firehose-receiver-for-graalvm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>oap-libs-for-graalvm</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>aws-firehose-receiver-for-graalvm</artifactId>

--- a/oap-libs-for-graalvm/cilium-fetcher-for-graalvm/pom.xml
+++ b/oap-libs-for-graalvm/cilium-fetcher-for-graalvm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>oap-libs-for-graalvm</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>cilium-fetcher-for-graalvm</artifactId>

--- a/oap-libs-for-graalvm/cilium-fetcher-for-graalvm/pom.xml
+++ b/oap-libs-for-graalvm/cilium-fetcher-for-graalvm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>oap-libs-for-graalvm</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cilium-fetcher-for-graalvm</artifactId>

--- a/oap-libs-for-graalvm/ebpf-receiver-for-graalvm/pom.xml
+++ b/oap-libs-for-graalvm/ebpf-receiver-for-graalvm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>oap-libs-for-graalvm</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ebpf-receiver-for-graalvm</artifactId>

--- a/oap-libs-for-graalvm/ebpf-receiver-for-graalvm/pom.xml
+++ b/oap-libs-for-graalvm/ebpf-receiver-for-graalvm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>oap-libs-for-graalvm</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>ebpf-receiver-for-graalvm</artifactId>

--- a/oap-libs-for-graalvm/envoy-metrics-receiver-for-graalvm/pom.xml
+++ b/oap-libs-for-graalvm/envoy-metrics-receiver-for-graalvm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>oap-libs-for-graalvm</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>envoy-metrics-receiver-for-graalvm</artifactId>

--- a/oap-libs-for-graalvm/envoy-metrics-receiver-for-graalvm/pom.xml
+++ b/oap-libs-for-graalvm/envoy-metrics-receiver-for-graalvm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>oap-libs-for-graalvm</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>envoy-metrics-receiver-for-graalvm</artifactId>

--- a/oap-libs-for-graalvm/health-checker-for-graalvm/pom.xml
+++ b/oap-libs-for-graalvm/health-checker-for-graalvm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>oap-libs-for-graalvm</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>health-checker-for-graalvm</artifactId>

--- a/oap-libs-for-graalvm/health-checker-for-graalvm/pom.xml
+++ b/oap-libs-for-graalvm/health-checker-for-graalvm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>oap-libs-for-graalvm</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>health-checker-for-graalvm</artifactId>

--- a/oap-libs-for-graalvm/library-module-for-graalvm/pom.xml
+++ b/oap-libs-for-graalvm/library-module-for-graalvm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>oap-libs-for-graalvm</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>library-module-for-graalvm</artifactId>

--- a/oap-libs-for-graalvm/library-module-for-graalvm/pom.xml
+++ b/oap-libs-for-graalvm/library-module-for-graalvm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>oap-libs-for-graalvm</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>library-module-for-graalvm</artifactId>

--- a/oap-libs-for-graalvm/library-util-for-graalvm/pom.xml
+++ b/oap-libs-for-graalvm/library-util-for-graalvm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>oap-libs-for-graalvm</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>library-util-for-graalvm</artifactId>

--- a/oap-libs-for-graalvm/library-util-for-graalvm/pom.xml
+++ b/oap-libs-for-graalvm/library-util-for-graalvm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>oap-libs-for-graalvm</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>library-util-for-graalvm</artifactId>

--- a/oap-libs-for-graalvm/log-analyzer-for-graalvm/pom.xml
+++ b/oap-libs-for-graalvm/log-analyzer-for-graalvm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>oap-libs-for-graalvm</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>log-analyzer-for-graalvm</artifactId>

--- a/oap-libs-for-graalvm/log-analyzer-for-graalvm/pom.xml
+++ b/oap-libs-for-graalvm/log-analyzer-for-graalvm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>oap-libs-for-graalvm</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>log-analyzer-for-graalvm</artifactId>

--- a/oap-libs-for-graalvm/meter-analyzer-for-graalvm/pom.xml
+++ b/oap-libs-for-graalvm/meter-analyzer-for-graalvm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>oap-libs-for-graalvm</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>meter-analyzer-for-graalvm</artifactId>

--- a/oap-libs-for-graalvm/meter-analyzer-for-graalvm/pom.xml
+++ b/oap-libs-for-graalvm/meter-analyzer-for-graalvm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>oap-libs-for-graalvm</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>meter-analyzer-for-graalvm</artifactId>

--- a/oap-libs-for-graalvm/otel-receiver-for-graalvm/pom.xml
+++ b/oap-libs-for-graalvm/otel-receiver-for-graalvm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>oap-libs-for-graalvm</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>otel-receiver-for-graalvm</artifactId>

--- a/oap-libs-for-graalvm/otel-receiver-for-graalvm/pom.xml
+++ b/oap-libs-for-graalvm/otel-receiver-for-graalvm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>oap-libs-for-graalvm</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>otel-receiver-for-graalvm</artifactId>

--- a/oap-libs-for-graalvm/pom.xml
+++ b/oap-libs-for-graalvm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>skywalking-graalvm-distro</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>oap-libs-for-graalvm</artifactId>

--- a/oap-libs-for-graalvm/pom.xml
+++ b/oap-libs-for-graalvm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>skywalking-graalvm-distro</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>oap-libs-for-graalvm</artifactId>

--- a/oap-libs-for-graalvm/server-core-for-graalvm/pom.xml
+++ b/oap-libs-for-graalvm/server-core-for-graalvm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>oap-libs-for-graalvm</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>server-core-for-graalvm</artifactId>

--- a/oap-libs-for-graalvm/server-core-for-graalvm/pom.xml
+++ b/oap-libs-for-graalvm/server-core-for-graalvm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>oap-libs-for-graalvm</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>server-core-for-graalvm</artifactId>

--- a/oap-libs-for-graalvm/server-starter-for-graalvm/pom.xml
+++ b/oap-libs-for-graalvm/server-starter-for-graalvm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>oap-libs-for-graalvm</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>server-starter-for-graalvm</artifactId>

--- a/oap-libs-for-graalvm/server-starter-for-graalvm/pom.xml
+++ b/oap-libs-for-graalvm/server-starter-for-graalvm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>oap-libs-for-graalvm</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>server-starter-for-graalvm</artifactId>

--- a/oap-libs-for-graalvm/status-query-for-graalvm/pom.xml
+++ b/oap-libs-for-graalvm/status-query-for-graalvm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>oap-libs-for-graalvm</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>status-query-for-graalvm</artifactId>

--- a/oap-libs-for-graalvm/status-query-for-graalvm/pom.xml
+++ b/oap-libs-for-graalvm/status-query-for-graalvm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>oap-libs-for-graalvm</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>status-query-for-graalvm</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>org.apache.skywalking</groupId>
     <artifactId>skywalking-graalvm-distro</artifactId>
-    <version>0.2.0</version>
+    <version>0.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>SkyWalking GraalVM Distro</name>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>org.apache.skywalking</groupId>
     <artifactId>skywalking-graalvm-distro</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.2.0</version>
     <packaging>pom</packaging>
 
     <name>SkyWalking GraalVM Distro</name>


### PR DESCRIPTION
Automated version bump after release 0.2.0.

- Bumps all pom.xml from `0.2.0` to `0.3.0-SNAPSHOT`
- Created by `release/full-release.sh`