### PR TITLE
Fix changes.md and rewrite pre-release.sh to use release branches

### DIFF
--- a/changes/changes.md
+++ b/changes/changes.md
@@ -1,5 +1,16 @@
 # Changes
 
+## 0.2.1
+
+### Build
+
+- Fix `version.properties` generation for source tarball builds: move antrun `copy-version-properties` to a Maven profile that only activates when `.git` exists, so pre-generated `version.properties` from `release.sh` is used in source tarball builds.
+
+### Release Tooling
+
+- Rewrite `release/pre-release.sh` to create a release branch (`release/v<version>`) instead of committing directly to main.
+- Add `changes/changes.md` verification to `release/pre-release.sh` (requires release notes section before proceeding).
+
 ## 0.2.0
 
 ### Highlights
@@ -33,7 +44,6 @@ Upgrade to the latest Apache SkyWalking OAP server, with documentation restructu
 - `release/release.sh`: fix SHA-512 checksum files to contain only hash + filename (no local paths).
 - `release/release.sh`: re-upload darwin SHA-512 to GitHub Release after GPG signing.
 - `release/release.sh`: link vote email to `compiling.md` instead of `quick-start.md`.
-- `release/full-release.sh`: end-to-end release script.
 - Generate vote email template with GPG signer info and submodule commit IDs.
 
 ### New Module
@@ -42,7 +52,7 @@ Upgrade to the latest Apache SkyWalking OAP server, with documentation restructu
 
 ### Build
 
-- Fix source tarball build: set `failonerror=false` for version generation; `release.sh` pre-generates `version.properties` in the source tarball.
+- Fix Armeria handler scan to detect inherited `@Get`/`@Path` annotations (precompiler).
 
 ### Testing
 
@@ -57,9 +67,11 @@ Upgrade to the latest Apache SkyWalking OAP server, with documentation restructu
 - Bump Istio to 1.28.0.
 - Add Baseline e2e test case.
 
-### Build
+## 0.1.1
 
-- Fix Armeria handler scan to detect inherited `@Get`/`@Path` annotations (precompiler).
+### Release Tooling
+
+- `release/full-release.sh`: end-to-end release script.
 
 ## 0.1.0
 

--- a/release/pre-release.sh
+++ b/release/pre-release.sh
@@ -24,6 +24,15 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 log()   { echo "===> $*"; }
 error() { echo "ERROR: $*" >&2; exit 1; }
 
+# ─── Pre-flight checks ──────────────────────────────────────────────────────
+cd "${REPO_ROOT}"
+
+CURRENT_BRANCH=$(git branch --show-current)
+[[ "${CURRENT_BRANCH}" == "main" ]] || error "Must be on main branch (currently on '${CURRENT_BRANCH}')"
+
+# Check for uncommitted changes
+[[ -z "$(git status --porcelain)" ]] || error "Working tree is not clean. Commit or stash changes first."
+
 # ─── Read current version from root pom.xml ──────────────────────────────────
 CURRENT_VERSION=$(sed -n 's/.*<version>\(.*\)<\/version>.*/\1/p' "${REPO_ROOT}/pom.xml" | head -1)
 [[ -n "${CURRENT_VERSION}" ]] || error "Could not read version from pom.xml"
@@ -40,27 +49,44 @@ RELEASE_VERSION="${RELEASE_VERSION:-${DEFAULT_RELEASE_VERSION}}"
 [[ "${RELEASE_VERSION}" != *-SNAPSHOT ]] || error "Release version must not contain -SNAPSHOT"
 
 # ─── Step 2: Determine next development version ─────────────────────────────
-# Default: bump minor version (0.1.0 -> 0.2.0-SNAPSHOT)
+# Default: bump patch version (0.2.0 -> 0.2.1-SNAPSHOT)
 IFS='.' read -r MAJOR MINOR PATCH <<< "${RELEASE_VERSION}"
-DEFAULT_NEXT_VERSION="${MAJOR}.$((MINOR + 1)).0-SNAPSHOT"
+DEFAULT_NEXT_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))-SNAPSHOT"
 
 echo ""
 read -r -p "Next development version [${DEFAULT_NEXT_VERSION}]: " NEXT_VERSION
 NEXT_VERSION="${NEXT_VERSION:-${DEFAULT_NEXT_VERSION}}"
 [[ "${NEXT_VERSION}" == *-SNAPSHOT ]] || error "Next development version must end with -SNAPSHOT"
 
+RELEASE_BRANCH="release/v${RELEASE_VERSION}"
+
+# ─── Verify changes.md ──────────────────────────────────────────────────────
+CHANGES_FILE="${REPO_ROOT}/changes/changes.md"
+[[ -f "${CHANGES_FILE}" ]] || error "changes/changes.md not found"
+if ! grep -q "^## ${RELEASE_VERSION}$" "${CHANGES_FILE}"; then
+    error "changes/changes.md does not contain a '## ${RELEASE_VERSION}' section. Add release notes before releasing."
+fi
+SECTION_CONTENT=$(sed -n "/^## ${RELEASE_VERSION}$/,/^## /p" "${CHANGES_FILE}" | sed '1d;/^## /d' | grep -v '^$' | head -1)
+[[ -n "${SECTION_CONTENT}" ]] \
+    || error "changes/changes.md has a '## ${RELEASE_VERSION}' section but it is empty. Add release notes."
+log "changes/changes.md: found release notes for ${RELEASE_VERSION}"
+
 # ─── Confirm ─────────────────────────────────────────────────────────────────
 echo ""
 echo "Summary:"
 echo "  Current version      : ${CURRENT_VERSION}"
 echo "  Release version      : ${RELEASE_VERSION}"
+echo "  Release branch       : ${RELEASE_BRANCH}"
 echo "  Next dev version     : ${NEXT_VERSION}"
 echo "  Tag                  : v${RELEASE_VERSION}"
 echo ""
 read -r -p "Proceed? [y/N] " confirm
 [[ "${confirm}" =~ ^[Yy]$ ]] || { echo "Aborted."; exit 0; }
 
-# ─── Step 3: Bump to release version ────────────────────────────────────────
+# ─── Step 3: Create release branch and bump to release version ───────────────
+log "Creating release branch ${RELEASE_BRANCH}..."
+git checkout -b "${RELEASE_BRANCH}"
+
 log "Bumping version to ${RELEASE_VERSION}..."
 
 find "${REPO_ROOT}" -name pom.xml -not -path '*/skywalking/*' \
@@ -71,19 +97,20 @@ VERIFY_VERSION=$(sed -n 's/.*<version>\(.*\)<\/version>.*/\1/p' "${REPO_ROOT}/po
 [[ "${VERIFY_VERSION}" == "${RELEASE_VERSION}" ]] || error "Version bump failed. pom.xml shows '${VERIFY_VERSION}'"
 
 log "Committing release version..."
-cd "${REPO_ROOT}"
-git add -A '*.pom.xml' 2>/dev/null || true
 git add $(find . -name pom.xml -not -path '*/skywalking/*')
 git commit -m "Release ${RELEASE_VERSION}"
 
 log "Creating tag v${RELEASE_VERSION}..."
 git tag "v${RELEASE_VERSION}"
 
-# ─── Step 4: Bump to next development version ───────────────────────────────
+# ─── Step 4: Switch back to main and bump to next development version ───────
+log "Switching back to main..."
+git checkout main
+
 log "Bumping version to ${NEXT_VERSION}..."
 
 find "${REPO_ROOT}" -name pom.xml -not -path '*/skywalking/*' \
-    -exec sed -i '' "s/${RELEASE_VERSION}/${NEXT_VERSION}/g" {} \;
+    -exec sed -i '' "s/${CURRENT_VERSION}/${NEXT_VERSION}/g" {} \;
 
 VERIFY_VERSION=$(sed -n 's/.*<version>\(.*\)<\/version>.*/\1/p' "${REPO_ROOT}/pom.xml" | head -1)
 [[ "${VERIFY_VERSION}" == "${NEXT_VERSION}" ]] || error "Version bump failed. pom.xml shows '${VERIFY_VERSION}'"
@@ -97,13 +124,16 @@ echo ""
 log "Pre-release complete!"
 echo ""
 echo "Created:"
-echo "  - Commit: Release ${RELEASE_VERSION}"
-echo "  - Tag:    v${RELEASE_VERSION}"
-echo "  - Commit: Bump version to ${NEXT_VERSION}"
+echo "  - Branch: ${RELEASE_BRANCH}"
+echo "    - Commit: Release ${RELEASE_VERSION}"
+echo "    - Tag:    v${RELEASE_VERSION}"
+echo "  - On main:"
+echo "    - Commit: Bump version to ${NEXT_VERSION}"
 echo ""
 echo "Next steps:"
-echo "  1. Review commits:  git log --oneline -3"
-echo "  2. Push tag:        git push origin v${RELEASE_VERSION}"
-echo "  3. Push branch:     git push origin main"
-echo "  4. Wait for CI release workflow to complete"
-echo "  5. Run:             release/release.sh ${RELEASE_VERSION}"
+echo "  1. Review:            git log --oneline -2 && git log --oneline ${RELEASE_BRANCH} -1"
+echo "  2. Push tag:          git push origin v${RELEASE_VERSION}"
+echo "  3. Push release:      git push origin ${RELEASE_BRANCH}"
+echo "  4. Push main:         git push origin main"
+echo "  5. Wait for CI release workflow to complete"
+echo "  6. Run:               release/release.sh ${RELEASE_VERSION}"


### PR DESCRIPTION
### Summary

- Fix `changes/changes.md`:
  - Add `0.2.1` section (version.properties Maven profile fix, pre-release.sh rewrite).
  - Add `0.1.1` section (move `full-release.sh` entry from 0.2.0).
  - Merge duplicate `### Build` sections in 0.2.0.
  - Remove stale `failonerror=false` note (replaced by Maven profile approach).
- Rewrite `release/pre-release.sh`:
  - Create a release branch (`release/v<version>`) instead of committing directly to main.
  - Add `changes/changes.md` verification (requires release notes section before proceeding).
  - Add pre-flight checks: must be on main, working tree must be clean.

- [x] License headers valid: `license-eye header check`