### PR TITLE
Fix release scripts when main already has next SNAPSHOT version

### DIFF
--- a/release/full-release.sh
+++ b/release/full-release.sh
@@ -76,49 +76,66 @@ echo ""
 "${SCRIPT_DIR}/pre-release.sh"
 
 # ─── Step 3: Extract versions from what pre-release.sh created ───────────────
-# After pre-release.sh: HEAD is "Bump version to X.Y.Z-SNAPSHOT", HEAD~1 is tagged "Release X.Y.Z"
+# After pre-release.sh, find the tag that was just created.
+# If main already had the next SNAPSHOT version, HEAD was not changed;
+# otherwise HEAD is the "Bump version to X.Y.Z-SNAPSHOT" commit.
 NEXT_VERSION=$(sed -n 's/.*<version>\(.*\)<\/version>.*/\1/p' "${REPO_ROOT}/pom.xml" | head -1)
-TAG=$(git describe --tags --abbrev=0 HEAD~1)
+
+# Find the most recent release tag reachable from the release branch
+# The tag is always on the release branch, not necessarily on main
+LATEST_RELEASE_BRANCH=$(git branch --list 'release/v*' --sort=-creatordate | head -1 | tr -d ' ')
+TAG=$(git describe --tags --abbrev=0 "${LATEST_RELEASE_BRANCH}")
 RELEASE_VERSION="${TAG#v}"
-SNAPSHOT_BRANCH="version/${NEXT_VERSION}"
 
 log "Detected: release=${RELEASE_VERSION}, tag=${TAG}, next=${NEXT_VERSION}"
 
-# ─── Step 4: Move snapshot commit to PR branch ──────────────────────────────
-# Current state: main has [Release X.Y.Z] -> [Bump version to X.Y.Z-SNAPSHOT]
-# We want: main stays at [Release X.Y.Z], PR branch has [Bump version to X.Y.Z-SNAPSHOT]
+# ─── Step 4: Handle snapshot version bump on main ────────────────────────────
+# Check if pre-release.sh created a snapshot bump commit on main
+HEAD_MSG=$(git log -1 --format=%s)
 
-log "Moving snapshot commit to branch ${SNAPSHOT_BRANCH}..."
+if [[ "${HEAD_MSG}" == "Bump version to ${NEXT_VERSION}" ]]; then
+    # Main has a new snapshot bump commit — move it to a PR branch
+    SNAPSHOT_BRANCH="version/${NEXT_VERSION}"
+    log "Moving snapshot commit to branch ${SNAPSHOT_BRANCH}..."
 
-# Create PR branch from current HEAD (which includes the snapshot bump)
-git checkout -b "${SNAPSHOT_BRANCH}"
+    git checkout -b "${SNAPSHOT_BRANCH}"
+    git checkout main
+    git reset --hard "${TAG}"
 
-# Reset main back to the release commit (the tagged one)
-git checkout main
-git reset --hard "${TAG}"
+    NEEDS_SNAPSHOT_PR=true
+else
+    # Main already had the correct SNAPSHOT version — no bump needed
+    log "Main already at ${NEXT_VERSION} — no version bump PR needed"
+    NEEDS_SNAPSHOT_PR=false
+fi
 
-# ─── Step 5: Push tag and PR branch ─────────────────────────────────────────
+# ─── Step 5: Push tag (and PR branch if needed) ─────────────────────────────
 log "Pushing tag ${TAG}..."
 git push origin "${TAG}"
 
-log "Pushing branch ${SNAPSHOT_BRANCH}..."
-git push -u origin "${SNAPSHOT_BRANCH}"
+log "Pushing release branch ${LATEST_RELEASE_BRANCH}..."
+git push origin "${LATEST_RELEASE_BRANCH}"
 
-log "Creating PR for version bump..."
-PR_URL=$(gh pr create \
-    --repo "${REPO}" \
-    --title "Bump version to ${NEXT_VERSION}" \
-    --body "$(cat <<EOF
+if [[ "${NEEDS_SNAPSHOT_PR}" == "true" ]]; then
+    log "Pushing branch ${SNAPSHOT_BRANCH}..."
+    git push -u origin "${SNAPSHOT_BRANCH}"
+
+    log "Creating PR for version bump..."
+    PR_URL=$(gh pr create \
+        --repo "${REPO}" \
+        --title "Bump version to ${NEXT_VERSION}" \
+        --body "$(cat <<EOF
 Automated version bump after release ${RELEASE_VERSION}.
 
 - Bumps all pom.xml from \`${RELEASE_VERSION}\` to \`${NEXT_VERSION}\`
 - Created by \`release/full-release.sh\`
 EOF
 )" \
-    --base main \
-    --head "${SNAPSHOT_BRANCH}" \
-    2>&1)
-log "PR created: ${PR_URL}"
+        --base main \
+        --head "${SNAPSHOT_BRANCH}" \
+        2>&1)
+    log "PR created: ${PR_URL}"
+fi
 
 # ─── Step 6: Wait for CI on tag ──────────────────────────────────────────────
 log "Waiting for CI workflow on tag ${TAG}..."

--- a/release/pre-release.sh
+++ b/release/pre-release.sh
@@ -107,17 +107,23 @@ git tag "v${RELEASE_VERSION}"
 log "Switching back to main..."
 git checkout main
 
-log "Bumping version to ${NEXT_VERSION}..."
+MAIN_NEEDS_BUMP=true
+if [[ "${CURRENT_VERSION}" == "${NEXT_VERSION}" ]]; then
+    log "Main already at ${NEXT_VERSION} — skipping version bump"
+    MAIN_NEEDS_BUMP=false
+else
+    log "Bumping version to ${NEXT_VERSION}..."
 
-find "${REPO_ROOT}" -name pom.xml -not -path '*/skywalking/*' \
-    -exec sed -i '' "s/${CURRENT_VERSION}/${NEXT_VERSION}/g" {} \;
+    find "${REPO_ROOT}" -name pom.xml -not -path '*/skywalking/*' \
+        -exec sed -i '' "s/${CURRENT_VERSION}/${NEXT_VERSION}/g" {} \;
 
-VERIFY_VERSION=$(sed -n 's/.*<version>\(.*\)<\/version>.*/\1/p' "${REPO_ROOT}/pom.xml" | head -1)
-[[ "${VERIFY_VERSION}" == "${NEXT_VERSION}" ]] || error "Version bump failed. pom.xml shows '${VERIFY_VERSION}'"
+    VERIFY_VERSION=$(sed -n 's/.*<version>\(.*\)<\/version>.*/\1/p' "${REPO_ROOT}/pom.xml" | head -1)
+    [[ "${VERIFY_VERSION}" == "${NEXT_VERSION}" ]] || error "Version bump failed. pom.xml shows '${VERIFY_VERSION}'"
 
-log "Committing next development version..."
-git add $(find . -name pom.xml -not -path '*/skywalking/*')
-git commit -m "Bump version to ${NEXT_VERSION}"
+    log "Committing next development version..."
+    git add $(find . -name pom.xml -not -path '*/skywalking/*')
+    git commit -m "Bump version to ${NEXT_VERSION}"
+fi
 
 # ─── Summary ─────────────────────────────────────────────────────────────────
 echo ""
@@ -127,13 +133,19 @@ echo "Created:"
 echo "  - Branch: ${RELEASE_BRANCH}"
 echo "    - Commit: Release ${RELEASE_VERSION}"
 echo "    - Tag:    v${RELEASE_VERSION}"
-echo "  - On main:"
-echo "    - Commit: Bump version to ${NEXT_VERSION}"
+if [[ "${MAIN_NEEDS_BUMP}" == "true" ]]; then
+    echo "  - On main:"
+    echo "    - Commit: Bump version to ${NEXT_VERSION}"
+else
+    echo "  - Main: already at ${NEXT_VERSION} (no changes)"
+fi
 echo ""
 echo "Next steps:"
-echo "  1. Review:            git log --oneline -2 && git log --oneline ${RELEASE_BRANCH} -1"
+echo "  1. Review:            git log --oneline ${RELEASE_BRANCH} -1"
 echo "  2. Push tag:          git push origin v${RELEASE_VERSION}"
 echo "  3. Push release:      git push origin ${RELEASE_BRANCH}"
-echo "  4. Push main:         git push origin main"
+if [[ "${MAIN_NEEDS_BUMP}" == "true" ]]; then
+    echo "  4. Push main:         git push origin main"
+fi
 echo "  5. Wait for CI release workflow to complete"
 echo "  6. Run:               release/release.sh ${RELEASE_VERSION}"


### PR DESCRIPTION
### Fix pre-release and full-release scripts for patch releases

When releasing a patch version (e.g. `0.2.1`) from a main branch that is already at the next minor SNAPSHOT (e.g. `0.3.0-SNAPSHOT`), the next dev version equals the current version. The scripts failed because:

- `pre-release.sh`: tried to commit a no-op version bump (`0.3.0-SNAPSHOT` → `0.3.0-SNAPSHOT`), failing with "nothing to commit"
- `full-release.sh`: assumed `HEAD` was always the snapshot bump commit and `HEAD~1` was the tagged release

**Changes:**

- `pre-release.sh`: skip version bump + commit on main when `CURRENT_VERSION == NEXT_VERSION`
- `full-release.sh`: detect whether a snapshot bump commit was created; skip PR branch/PR creation when not needed; find the tag from the release branch instead of `HEAD~1`

- [x] License headers valid: `license-eye header check`