### PR TITLE
Fix GitHub Release to include only version-specific changelog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,14 +483,19 @@ jobs:
       - name: Read changelog
         id: changelog
         run: |
-          # Use version-specific changelog if exists, otherwise default changes.md
           VERSION="${{ needs.init-skywalking.outputs.version }}"
-          if [[ -f "changes/${VERSION}.md" ]]; then
-            BODY_FILE="changes/${VERSION}.md"
-          else
-            BODY_FILE="changes/changes.md"
-          fi
-          echo "body-file=${BODY_FILE}" >> "$GITHUB_OUTPUT"
+          # Extract only the section for this version from changes.md
+          # (from "## {version}" up to the next "## " heading or EOF)
+          found=false
+          while IFS= read -r line; do
+            if [[ "${line}" == "## ${VERSION}" ]]; then
+              found=true
+            elif [[ "${line}" == "## "* ]] && $found; then
+              break
+            fi
+            $found && echo "${line}"
+          done < changes/changes.md > /tmp/release-notes.md
+          echo "body-file=/tmp/release-notes.md" >> "$GITHUB_OUTPUT"
 
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
### Summary

- Fix the `github-release` job to extract only the release version's section from `changes/changes.md` instead of including the entire file.
- Previously, the GitHub Release page showed all historical changes across all versions.
- Now it extracts content between `## {version}` and the next `## ` heading (or EOF).

- [x] License headers valid: `license-eye header check`