### PR TITLE
Add 13 e2e test cases for infrastructure monitoring and TLS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,6 +339,32 @@ jobs:
             case: exporter
           - name: SSL
             case: ssl
+          - name: mTLS
+            case: mtls
+          - name: RabbitMQ
+            case: rabbitmq
+          - name: RocketMQ
+            case: rocketmq
+          - name: ActiveMQ
+            case: activemq
+          - name: Pulsar
+            case: pulsar
+          - name: Kafka Monitoring
+            case: kafka-monitoring
+          - name: Redis
+            case: redis
+          - name: MongoDB
+            case: mongodb
+          - name: Flink
+            case: flink
+          - name: AWS DynamoDB
+            case: aws-dynamodb
+          - name: AWS S3
+            case: aws-s3
+          - name: AWS EKS
+            case: aws-eks
+          - name: AWS API Gateway
+            case: aws-api-gateway
           - name: Self Observability
             case: so11y
           - name: MQE
@@ -373,8 +399,8 @@ jobs:
           key: ${{ needs.init-skywalking.outputs.cache-key }}
           restore-keys: m2-skywalking-
 
-      - name: Build mock sender jar (baseline only)
-        if: matrix.test.case == 'baseline'
+      - name: Build mock sender jar
+        if: contains(fromJSON('["baseline","aws-dynamodb","aws-s3","aws-eks","aws-api-gateway"]'), matrix.test.case)
         run: |
           cd skywalking && ./mvnw -B -q \
             -f test/e2e-v2/java-test-service/pom.xml \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,11 @@ jobs:
       - name: Test
         run: make test
 
+      - name: Verify version-mapping doc
+        run: |
+          git fetch --tags --no-recurse-submodules origin
+          bash test/doc-scripts/verify-version-mapping.sh
+
       - name: Build distribution
         run: make build-distro
 
@@ -385,14 +390,14 @@ jobs:
         run: docker load -i /tmp/skywalking-oap-native.tar
 
       - name: Set up JDK 17 (test service build)
-        if: matrix.test.case == 'baseline' || matrix.test.case == 'mqe'
+        if: contains(fromJSON('["baseline","mqe","aws-dynamodb","aws-s3","aws-eks","aws-api-gateway"]'), matrix.test.case)
         uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Restore Maven cache (test service build)
-        if: matrix.test.case == 'baseline' || matrix.test.case == 'mqe'
+        if: contains(fromJSON('["baseline","mqe","aws-dynamodb","aws-s3","aws-eks","aws-api-gateway"]'), matrix.test.case)
         uses: actions/cache/restore@v5
         with:
           path: ~/.m2/repository

--- a/changes/changes.md
+++ b/changes/changes.md
@@ -17,6 +17,9 @@
 ### E2E Tests
 
 - Add SSL e2e test case (gRPC TLS with JDK SSL provider in native image).
+- Add mTLS e2e test case (mutual TLS with client certificates).
+- Add RabbitMQ, RocketMQ, ActiveMQ, Pulsar, Kafka, Redis, MongoDB, Flink monitoring e2e test cases (OTEL metrics collection).
+- Add AWS DynamoDB, S3, EKS, API Gateway e2e test cases (mock sender metrics).
 - Add Auth e2e test case (token-based agent-to-OAP authentication).
 - Add OTLP Traces e2e test case (OpenTelemetry trace ingestion via Zipkin API).
 - Add Virtual MQ e2e test case (Kafka-instrumented virtual MQ layer metrics).

--- a/docs/version-mapping.md
+++ b/docs/version-mapping.md
@@ -1,0 +1,18 @@
+# Version Mapping
+
+Maps each distro release to the upstream Apache SkyWalking version it is built from.
+
+When the submodule commit matches an upstream release tag, the upstream version is shown directly.
+Otherwise, it is shown as `{commit-id}-SNAPSHOT` indicating a development build ahead of the last release.
+
+<!-- DOC-CHECK: version-mapping-table -->
+| Distro Version | Apache SkyWalking Version |
+|---|---|
+| 0.1.0-rc0 | `2709c94ab3cc`-SNAPSHOT |
+| 0.1.0-rc1 | `2709c94ab3cc`-SNAPSHOT |
+| 0.1.0 | `64a1795d8a58`-SNAPSHOT |
+| 0.1.1 | `64a1795d8a58`-SNAPSHOT |
+| 0.2.0 | `64a1795d8a58`-SNAPSHOT |
+| 0.2.1 | `64a1795d8a58`-SNAPSHOT |
+| 0.3.0-SNAPSHOT (dev) | `726ebcc321db`-SNAPSHOT |
+<!-- END DOC-CHECK -->

--- a/oap-libs-for-graalvm/meter-analyzer-for-graalvm/src/main/java/org/apache/skywalking/oap/meter/analyzer/v2/prometheus/rule/Rules.java
+++ b/oap-libs-for-graalvm/meter-analyzer-for-graalvm/src/main/java/org/apache/skywalking/oap/meter/analyzer/v2/prometheus/rule/Rules.java
@@ -82,12 +82,32 @@ public class Rules {
                 .collect(Collectors.toSet());
 
             List<Rule> result = allRules.stream()
-                .filter(r -> normalizedEnabled.contains(r.getName()))
+                .filter(r -> matchesAny(r.getName(), normalizedEnabled))
                 .collect(Collectors.toList());
 
             LOG.info("Loaded {} pre-compiled rules from {} (filtered from {} available, enabled: {})",
                 result.size(), path, allRules.size(), normalizedEnabled);
             return result;
         }
+    }
+
+    /**
+     * Check if a rule name matches any of the enabled patterns.
+     * Supports glob patterns: {@code rabbitmq/*} matches {@code rabbitmq/rabbitmq-cluster}.
+     * A pattern ending with {@code /*} matches any rule whose name starts with the prefix before {@code /*}.
+     * Patterns without wildcards require exact match.
+     */
+    private static boolean matchesAny(final String ruleName, final Set<String> patterns) {
+        for (final String pattern : patterns) {
+            if (pattern.endsWith("/*")) {
+                String prefix = pattern.substring(0, pattern.length() - 1);
+                if (ruleName.startsWith(prefix)) {
+                    return true;
+                }
+            } else if (pattern.equals(ruleName)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/test/doc-scripts/verify-version-mapping.sh
+++ b/test/doc-scripts/verify-version-mapping.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verify docs/version-mapping.md is consistent with actual git state.
+#
+# Checks:
+# 1. The dev row's upstream version matches the current submodule commit.
+# 2. Each released version row matches the submodule commit at that git tag.
+#
+# Exit 0 on success, 1 on any mismatch.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+DOC="$REPO_ROOT/docs/version-mapping.md"
+
+if [ ! -f "$DOC" ]; then
+    echo "ERROR: $DOC not found"
+    exit 1
+fi
+
+errors=0
+
+# Resolve upstream version string for a submodule commit.
+# If the commit has an upstream tag (vX.Y.Z), return that version.
+# Otherwise, return "{short-commit}-SNAPSHOT".
+resolve_upstream_version() {
+    local commit="$1"
+    local short
+    short=$(echo "$commit" | cut -c1-12)
+    local tag
+    tag=$(cd "$REPO_ROOT/skywalking" && git tag --points-at "$commit" 2>/dev/null | grep "^v" | head -1)
+    if [ -n "$tag" ]; then
+        # Strip leading 'v' from tag
+        echo "${tag#v}"
+    else
+        echo "\`${short}\`-SNAPSHOT"
+    fi
+}
+
+# Parse table rows between DOC-CHECK markers.
+# Expected format: | Distro Version | Apache SkyWalking Version |
+in_table=0
+while IFS= read -r line; do
+    # Detect marker boundaries
+    if echo "$line" | grep -q "DOC-CHECK: version-mapping-table"; then
+        in_table=1
+        continue
+    fi
+    if echo "$line" | grep -q "END DOC-CHECK"; then
+        in_table=0
+        continue
+    fi
+    [ "$in_table" -eq 0 ] && continue
+
+    # Skip header and separator rows
+    echo "$line" | grep -qE "^\|.*\|$" || continue
+    echo "$line" | grep -q "\-\-\-" && continue
+    echo "$line" | grep -q "Distro Version" && continue
+
+    # Extract columns
+    distro_ver=$(echo "$line" | awk -F'|' '{print $2}' | xargs)
+    doc_upstream=$(echo "$line" | awk -F'|' '{print $3}' | xargs)
+
+    if echo "$distro_ver" | grep -q "(dev)"; then
+        # Dev row: verify against current submodule commit
+        actual_commit=$(git -C "$REPO_ROOT" ls-tree HEAD skywalking | awk '{print $3}')
+        expected=$(resolve_upstream_version "$actual_commit")
+
+        if [ "$doc_upstream" != "$expected" ]; then
+            echo "MISMATCH [dev]: doc says '$doc_upstream' but submodule is at '$expected'"
+            errors=$((errors + 1))
+        else
+            echo "OK [dev]: $distro_ver -> $doc_upstream"
+        fi
+    else
+        # Released version: verify against git tag
+        tag="v$distro_ver"
+        if ! git -C "$REPO_ROOT" rev-parse "$tag" >/dev/null 2>&1; then
+            echo "WARN [$distro_ver]: tag $tag not found (skipping — may not exist in shallow clone)"
+            continue
+        fi
+
+        actual_commit=$(git -C "$REPO_ROOT" ls-tree "$tag" skywalking | awk '{print $3}')
+        if [ -z "$actual_commit" ]; then
+            echo "WARN [$distro_ver]: no submodule entry at tag $tag"
+            continue
+        fi
+
+        expected=$(resolve_upstream_version "$actual_commit")
+        if [ "$doc_upstream" != "$expected" ]; then
+            echo "MISMATCH [$distro_ver]: doc says '$doc_upstream' but tag $tag has '$expected'"
+            errors=$((errors + 1))
+        else
+            echo "OK [$distro_ver]: $tag -> $doc_upstream"
+        fi
+    fi
+done < "$DOC"
+
+if [ "$errors" -gt 0 ]; then
+    echo ""
+    echo "FAILED: $errors version mapping mismatch(es) found."
+    echo "Update docs/version-mapping.md to match actual submodule state."
+    exit 1
+fi
+
+echo ""
+echo "All version mappings verified."

--- a/test/e2e/cases/activemq/docker-compose.yml
+++ b/test/e2e/cases/activemq/docker-compose.yml
@@ -1,0 +1,118 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+services:
+  banyandb:
+    extends:
+      file: ../../../../skywalking/test/e2e-v2/script/docker-compose/base-compose.yml
+      service: banyandb
+    ports:
+      - 17912
+
+  oap:
+    image: skywalking-oap-native:latest
+    expose:
+      - 11800
+      - 12800
+    networks:
+      - e2e
+    ports:
+      - 12800
+    environment:
+      SW_HEALTH_CHECKER: default
+      SW_STORAGE_BANYANDB_TARGETS: banyandb:17912
+      SW_CONFIGURATION: none
+    depends_on:
+      banyandb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "nc -nz 127.0.0.1 11800 || exit 1"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  amq:
+    image: apache/activemq-classic:6.0.1
+    hostname: amq
+    ports:
+      - "61616:61616"
+      - "8161:8161"
+    expose:
+      - 1616
+    volumes:
+      - ../../../../skywalking/test/e2e-v2/cases/activemq/config/amq/activemq.xml:/opt/apache-activemq/conf/activemq.xml
+    environment:
+      ACTIVEMQ_SUNJMX_START: "-Dcom.sun.management.jmxremote.port=1616 -Dcom.sun.management.jmxremote.rmi.port=1616 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
+      ACTIVEMQ_BROKER_NAME: activemq-broker
+    healthcheck:
+      test: [ "CMD-SHELL", "curl --silent --fail localhost:8161 || exit 1" ]
+      interval: 15s
+      timeout: 10s
+      retries: 120
+    networks:
+      - e2e
+
+  amqexporter:
+    image: bitnamilegacy/jmx-exporter:0.20.0
+    hostname: amqexporter
+    volumes:
+      - ../../../../skywalking/test/e2e-v2/cases/activemq/config/amq/config.yaml:/opt/bitnami/jmx-exporter/example_configs/httpserver_sample_config.yml
+    expose:
+      - 5556
+    depends_on:
+      - amq
+    networks:
+      - e2e
+
+  amq-consumer-mock:
+    image: apache/activemq-classic:6.0.1
+    hostname: amq-consumer-mock
+    entrypoint: bash
+    command:
+      - -c
+      - "/opt/apache-activemq/bin/activemq consumer --brokerUrl tcp://amq:61616 --destination queue://testQueue --messageCount 10 --parallelThreads 2 && /opt/apache-activemq/bin/activemq consumer --brokerUrl tcp://amq:61616 --destination topic://testTopic --messageCount 10 --parallelThreads 2"
+    depends_on:
+      amq:
+        condition: service_healthy
+    networks:
+      - e2e
+
+  amq-producer-mock:
+    image: apache/activemq-classic:6.0.1
+    hostname: amq-producer-mock
+    entrypoint: bash
+    command:
+      - -c
+      - "/opt/apache-activemq/bin/activemq producer --brokerUrl tcp://amq:61616 --destination queue://testQueue --messageCount 50 --persistent true --message hello && /opt/apache-activemq/bin/activemq producer --brokerUrl tcp://amq:61616 --destination topic://testTopic --messageCount 50 --persistent true --message world"
+    depends_on:
+      - amq-consumer-mock
+    networks:
+      - e2e
+
+  otel-collector:
+    image: otel/opentelemetry-collector:${OTEL_COLLECTOR_VERSION}
+    networks:
+      - e2e
+    command: [ "--config=/etc/otel-collector-config.yaml" ]
+    volumes:
+      - ../../../../skywalking/test/e2e-v2/cases/activemq/otel-collector-config.yaml:/etc/otel-collector-config.yaml
+    expose:
+      - 55678
+    depends_on:
+      oap:
+        condition: service_healthy
+
+networks:
+  e2e:

--- a/test/e2e/cases/activemq/e2e.yaml
+++ b/test/e2e/cases/activemq/e2e.yaml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+setup:
+  env: compose
+  file: docker-compose.yml
+  timeout: 20m
+  init-system-environment: ../../script/env
+  steps:
+    - name: set PATH
+      command: export PATH=/tmp/skywalking-infra-e2e/bin:$PATH
+    - name: install yq
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh yq
+    - name: install swctl
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh swctl
+
+verify:
+  retry:
+    count: 60
+    interval: 3s
+  cases:
+    - includes:
+        - ../../../../skywalking/test/e2e-v2/cases/activemq/activemq-cases.yaml

--- a/test/e2e/cases/aws-api-gateway/docker-compose.yml
+++ b/test/e2e/cases/aws-api-gateway/docker-compose.yml
@@ -56,7 +56,7 @@ services:
     networks:
       - e2e
     ports:
-      - 9093
+      - 9093:9093
     healthcheck:
       test: ["CMD", "sh", "-c", "nc -nz 127.0.0.1 9093"]
       interval: 5s

--- a/test/e2e/cases/aws-api-gateway/docker-compose.yml
+++ b/test/e2e/cases/aws-api-gateway/docker-compose.yml
@@ -1,0 +1,70 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+services:
+  banyandb:
+    extends:
+      file: ../../../../skywalking/test/e2e-v2/script/docker-compose/base-compose.yml
+      service: banyandb
+    ports:
+      - 17912
+
+  oap:
+    image: skywalking-oap-native:latest
+    expose:
+      - 11800
+      - 12800
+    networks:
+      - e2e
+    ports:
+      - 12800
+    environment:
+      SW_HEALTH_CHECKER: default
+      SW_STORAGE_BANYANDB_TARGETS: banyandb:17912
+      SW_CONFIGURATION: none
+    depends_on:
+      banyandb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "nc -nz 127.0.0.1 11800 || exit 1"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  sender:
+    image: "eclipse-temurin:8-jre"
+    volumes:
+      - ../../../../skywalking/test/e2e-v2/java-test-service/e2e-mock-sender/target/e2e-mock-sender-2.0.0.jar:/e2e-mock-sender-2.0.0.jar
+      - ../../../../skywalking/test/e2e-v2/cases/aws/api-gateway/mock-data:/data/otel-metrics
+    command: ["java", "-jar", "/e2e-mock-sender-2.0.0.jar"]
+    environment:
+      OAP_HOST: oap
+      OAP_GRPC_PORT: 11800
+      OTEL_METRICS_DATA_PATH: /data/otel-metrics
+    networks:
+      - e2e
+    ports:
+      - 9093
+    healthcheck:
+      test: ["CMD", "sh", "-c", "nc -nz 127.0.0.1 9093"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+    depends_on:
+      oap:
+        condition: service_healthy
+
+networks:
+  e2e:

--- a/test/e2e/cases/aws-api-gateway/e2e.yaml
+++ b/test/e2e/cases/aws-api-gateway/e2e.yaml
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+setup:
+  env: compose
+  file: docker-compose.yml
+  timeout: 20m
+  init-system-environment: ../../script/env
+  steps:
+    - name: set PATH
+      command: export PATH=/tmp/skywalking-infra-e2e/bin:$PATH
+    - name: install yq
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh yq
+    - name: install swctl
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh swctl
+
+trigger:
+  action: http
+  interval: 3s
+  times: -1
+  url: http://localhost:9093/otel-metrics/send
+  method: GET
+
+verify:
+  retry:
+    count: 20
+    interval: 10s
+  cases:
+    - includes:
+        - ../../../../skywalking/test/e2e-v2/cases/aws/api-gateway/gateway-cases.yaml

--- a/test/e2e/cases/aws-dynamodb/docker-compose.yml
+++ b/test/e2e/cases/aws-dynamodb/docker-compose.yml
@@ -56,7 +56,7 @@ services:
     networks:
       - e2e
     ports:
-      - 9093
+      - 9093:9093
     healthcheck:
       test: ["CMD", "sh", "-c", "nc -nz 127.0.0.1 9093"]
       interval: 5s

--- a/test/e2e/cases/aws-dynamodb/docker-compose.yml
+++ b/test/e2e/cases/aws-dynamodb/docker-compose.yml
@@ -1,0 +1,70 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+services:
+  banyandb:
+    extends:
+      file: ../../../../skywalking/test/e2e-v2/script/docker-compose/base-compose.yml
+      service: banyandb
+    ports:
+      - 17912
+
+  oap:
+    image: skywalking-oap-native:latest
+    expose:
+      - 11800
+      - 12800
+    networks:
+      - e2e
+    ports:
+      - 12800
+    environment:
+      SW_HEALTH_CHECKER: default
+      SW_STORAGE_BANYANDB_TARGETS: banyandb:17912
+      SW_CONFIGURATION: none
+    depends_on:
+      banyandb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "nc -nz 127.0.0.1 11800 || exit 1"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  sender:
+    image: "eclipse-temurin:8-jre"
+    volumes:
+      - ../../../../skywalking/test/e2e-v2/java-test-service/e2e-mock-sender/target/e2e-mock-sender-2.0.0.jar:/e2e-mock-sender-2.0.0.jar
+      - ../../../../skywalking/test/e2e-v2/cases/aws/dynamodb/mock-data:/data/otel-metrics
+    command: ["java", "-jar", "/e2e-mock-sender-2.0.0.jar"]
+    environment:
+      OAP_HOST: oap
+      OAP_GRPC_PORT: 11800
+      OTEL_METRICS_DATA_PATH: /data/otel-metrics
+    networks:
+      - e2e
+    ports:
+      - 9093
+    healthcheck:
+      test: ["CMD", "sh", "-c", "nc -nz 127.0.0.1 9093"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+    depends_on:
+      oap:
+        condition: service_healthy
+
+networks:
+  e2e:

--- a/test/e2e/cases/aws-dynamodb/e2e.yaml
+++ b/test/e2e/cases/aws-dynamodb/e2e.yaml
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+setup:
+  env: compose
+  file: docker-compose.yml
+  timeout: 20m
+  init-system-environment: ../../script/env
+  steps:
+    - name: set PATH
+      command: export PATH=/tmp/skywalking-infra-e2e/bin:$PATH
+    - name: install yq
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh yq
+    - name: install swctl
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh swctl
+
+trigger:
+  action: http
+  interval: 3s
+  times: -1
+  url: http://localhost:9093/otel-metrics/send
+  method: GET
+
+verify:
+  retry:
+    count: 20
+    interval: 10s
+  cases:
+    - includes:
+        - ../../../../skywalking/test/e2e-v2/cases/aws/dynamodb/dynamodb-cases.yaml

--- a/test/e2e/cases/aws-eks/docker-compose.yml
+++ b/test/e2e/cases/aws-eks/docker-compose.yml
@@ -56,7 +56,7 @@ services:
     networks:
       - e2e
     ports:
-      - 9093
+      - 9093:9093
     healthcheck:
       test: ["CMD", "sh", "-c", "nc -nz 127.0.0.1 9093"]
       interval: 5s

--- a/test/e2e/cases/aws-eks/docker-compose.yml
+++ b/test/e2e/cases/aws-eks/docker-compose.yml
@@ -1,0 +1,70 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+services:
+  banyandb:
+    extends:
+      file: ../../../../skywalking/test/e2e-v2/script/docker-compose/base-compose.yml
+      service: banyandb
+    ports:
+      - 17912
+
+  oap:
+    image: skywalking-oap-native:latest
+    expose:
+      - 11800
+      - 12800
+    networks:
+      - e2e
+    ports:
+      - 12800
+    environment:
+      SW_HEALTH_CHECKER: default
+      SW_STORAGE_BANYANDB_TARGETS: banyandb:17912
+      SW_CONFIGURATION: none
+    depends_on:
+      banyandb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "nc -nz 127.0.0.1 11800 || exit 1"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  sender:
+    image: "eclipse-temurin:8-jre"
+    volumes:
+      - ../../../../skywalking/test/e2e-v2/java-test-service/e2e-mock-sender/target/e2e-mock-sender-2.0.0.jar:/e2e-mock-sender-2.0.0.jar
+      - ../../../../skywalking/test/e2e-v2/cases/aws/eks/mock-data:/data/otel-metrics
+    command: ["java", "-jar", "/e2e-mock-sender-2.0.0.jar"]
+    environment:
+      OAP_HOST: oap
+      OAP_GRPC_PORT: 11800
+      OTEL_METRICS_DATA_PATH: /data/otel-metrics
+    networks:
+      - e2e
+    ports:
+      - 9093
+    healthcheck:
+      test: ["CMD", "sh", "-c", "nc -nz 127.0.0.1 9093"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+    depends_on:
+      oap:
+        condition: service_healthy
+
+networks:
+  e2e:

--- a/test/e2e/cases/aws-eks/e2e.yaml
+++ b/test/e2e/cases/aws-eks/e2e.yaml
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+setup:
+  env: compose
+  file: docker-compose.yml
+  timeout: 20m
+  init-system-environment: ../../script/env
+  steps:
+    - name: set PATH
+      command: export PATH=/tmp/skywalking-infra-e2e/bin:$PATH
+    - name: install yq
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh yq
+    - name: install swctl
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh swctl
+
+trigger:
+  action: http
+  interval: 3s
+  times: -1
+  url: http://localhost:9093/otel-metrics/send
+  method: GET
+
+verify:
+  retry:
+    count: 20
+    interval: 10s
+  cases:
+    - includes:
+        - ../../../../skywalking/test/e2e-v2/cases/aws/eks/eks-cases.yaml

--- a/test/e2e/cases/aws-s3/docker-compose.yml
+++ b/test/e2e/cases/aws-s3/docker-compose.yml
@@ -56,7 +56,7 @@ services:
     networks:
       - e2e
     ports:
-      - 9093
+      - 9093:9093
     healthcheck:
       test: ["CMD", "sh", "-c", "nc -nz 127.0.0.1 9093"]
       interval: 5s

--- a/test/e2e/cases/aws-s3/docker-compose.yml
+++ b/test/e2e/cases/aws-s3/docker-compose.yml
@@ -1,0 +1,70 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+services:
+  banyandb:
+    extends:
+      file: ../../../../skywalking/test/e2e-v2/script/docker-compose/base-compose.yml
+      service: banyandb
+    ports:
+      - 17912
+
+  oap:
+    image: skywalking-oap-native:latest
+    expose:
+      - 11800
+      - 12800
+    networks:
+      - e2e
+    ports:
+      - 12800
+    environment:
+      SW_HEALTH_CHECKER: default
+      SW_STORAGE_BANYANDB_TARGETS: banyandb:17912
+      SW_CONFIGURATION: none
+    depends_on:
+      banyandb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "nc -nz 127.0.0.1 11800 || exit 1"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  sender:
+    image: "eclipse-temurin:8-jre"
+    volumes:
+      - ../../../../skywalking/test/e2e-v2/java-test-service/e2e-mock-sender/target/e2e-mock-sender-2.0.0.jar:/e2e-mock-sender-2.0.0.jar
+      - ../../../../skywalking/test/e2e-v2/cases/aws/s3/mock-data:/data/otel-metrics
+    command: ["java", "-jar", "/e2e-mock-sender-2.0.0.jar"]
+    environment:
+      OAP_HOST: oap
+      OAP_GRPC_PORT: 11800
+      OTEL_METRICS_DATA_PATH: /data/otel-metrics
+    networks:
+      - e2e
+    ports:
+      - 9093
+    healthcheck:
+      test: ["CMD", "sh", "-c", "nc -nz 127.0.0.1 9093"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+    depends_on:
+      oap:
+        condition: service_healthy
+
+networks:
+  e2e:

--- a/test/e2e/cases/aws-s3/e2e.yaml
+++ b/test/e2e/cases/aws-s3/e2e.yaml
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+setup:
+  env: compose
+  file: docker-compose.yml
+  timeout: 20m
+  init-system-environment: ../../script/env
+  steps:
+    - name: set PATH
+      command: export PATH=/tmp/skywalking-infra-e2e/bin:$PATH
+    - name: install yq
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh yq
+    - name: install swctl
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh swctl
+
+trigger:
+  action: http
+  interval: 3s
+  times: -1
+  url: http://localhost:9093/otel-metrics/send
+  method: GET
+
+verify:
+  retry:
+    count: 20
+    interval: 10s
+  cases:
+    - includes:
+        - ../../../../skywalking/test/e2e-v2/cases/aws/s3/s3-cases.yaml

--- a/test/e2e/cases/flink/docker-compose.yml
+++ b/test/e2e/cases/flink/docker-compose.yml
@@ -1,0 +1,113 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+services:
+  banyandb:
+    extends:
+      file: ../../../../skywalking/test/e2e-v2/script/docker-compose/base-compose.yml
+      service: banyandb
+    ports:
+      - 17912
+
+  oap:
+    image: skywalking-oap-native:latest
+    expose:
+      - 11800
+      - 12800
+    networks:
+      - e2e
+    ports:
+      - 12800
+    environment:
+      SW_HEALTH_CHECKER: default
+      SW_STORAGE_BANYANDB_TARGETS: banyandb:17912
+      SW_CONFIGURATION: none
+    depends_on:
+      banyandb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "nc -nz 127.0.0.1 11800 || exit 1"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  jobmanager:
+    image: flink:2.0-preview1
+    environment:
+      - |
+        FLINK_PROPERTIES=
+        jobmanager.rpc.address: jobmanager
+        metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory
+        metrics.reporter.prom.port: 9260
+    ports:
+      - "8081:8081"
+      - "9260:9260"
+    command: jobmanager
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8081"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - e2e
+
+  taskmanager:
+    image: flink:2.0-preview1
+    environment:
+      - |
+        FLINK_PROPERTIES=
+        jobmanager.rpc.address: jobmanager
+        metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory
+        metrics.reporter.prom.port: 9261
+    depends_on:
+      jobmanager:
+        condition: service_healthy
+    ports:
+      - "9261:9261"
+    command: taskmanager
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9261/metrics"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - e2e
+
+  executeJob:
+    image: flink:2.0-preview1
+    depends_on:
+      taskmanager:
+        condition: service_healthy
+    command: >
+      bash -c "
+      ./bin/flink run -m jobmanager:8081 examples/streaming/WindowJoin.jar"
+    networks:
+      - e2e
+
+  otel-collector:
+    image: otel/opentelemetry-collector:${OTEL_COLLECTOR_VERSION}
+    networks:
+      - e2e
+    command: [ "--config=/etc/otel-collector-config.yaml" ]
+    volumes:
+      - ../../../../skywalking/test/e2e-v2/cases/flink/otel-collector-config.yaml:/etc/otel-collector-config.yaml
+    expose:
+      - 55678
+    depends_on:
+      oap:
+        condition: service_healthy
+
+networks:
+  e2e:

--- a/test/e2e/cases/flink/e2e.yaml
+++ b/test/e2e/cases/flink/e2e.yaml
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+setup:
+  env: compose
+  file: docker-compose.yml
+  timeout: 20m
+  init-system-environment: ../../script/env
+  steps:
+    - name: set PATH
+      command: export PATH=/tmp/skywalking-infra-e2e/bin:$PATH
+    - name: install yq
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh yq
+    - name: install swctl
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh swctl
+
+trigger:
+  action: http
+  interval: 3s
+  times: -1
+  url: http://${jobmanager_host}:${jobmanager_9260}/metrics
+  method: GET
+
+verify:
+  retry:
+    count: 60
+    interval: 3s
+  cases:
+    - includes:
+        - ../../../../skywalking/test/e2e-v2/cases/flink/flink-cases.yaml

--- a/test/e2e/cases/kafka-monitoring/docker-compose.yml
+++ b/test/e2e/cases/kafka-monitoring/docker-compose.yml
@@ -1,0 +1,141 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+services:
+  banyandb:
+    extends:
+      file: ../../../../skywalking/test/e2e-v2/script/docker-compose/base-compose.yml
+      service: banyandb
+    ports:
+      - 17912
+
+  oap:
+    image: skywalking-oap-native:latest
+    expose:
+      - 11800
+      - 12800
+    networks:
+      - e2e
+    ports:
+      - 12800
+    environment:
+      SW_HEALTH_CHECKER: default
+      SW_STORAGE_BANYANDB_TARGETS: banyandb:17912
+      SW_CONFIGURATION: none
+    depends_on:
+      banyandb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "nc -nz 127.0.0.1 11800 || exit 1"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  zookeeper:
+    image: zookeeper:3.4
+    expose:
+      - 2181
+    networks:
+      - e2e
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+    healthcheck:
+      test: ["CMD", "sh", "-c", "nc -nz 127.0.0.1 2181"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  broker1:
+    build:
+      context: ../../../../skywalking/test/e2e-v2/cases/kafka/kafka-monitoring
+    expose:
+      - 9092
+      - 7071
+    networks:
+      - e2e
+    environment:
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_OPTS=-javaagent:/etc/jmx_prometheus_javaagent-0.18.0.jar=7071:/etc/kafka-2_0_0.yml
+    depends_on:
+      zookeeper:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "kafka-topics.sh", "--list", "--zookeeper", "zookeeper:2181"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  broker2:
+    build:
+      context: ../../../../skywalking/test/e2e-v2/cases/kafka/kafka-monitoring
+    expose:
+      - 9093
+      - 7072
+    networks:
+      - e2e
+    environment:
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_OPTS=-javaagent:/etc/jmx_prometheus_javaagent-0.18.0.jar=7072:/etc/kafka-2_0_0.yml
+    depends_on:
+      zookeeper:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "kafka-topics.sh", "--list", "--zookeeper", "zookeeper:2181"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  kafka-producer-perf-test:
+    image: bitnamilegacy/kafka:2.4.1
+    networks:
+      - e2e
+    depends_on:
+      - broker1
+      - broker2
+    command:
+      - bash
+      - -c
+      - >
+        kafka-producer-perf-test.sh --topic perftest --num-records 100000 --record-size 100 --throughput 500 --producer-props bootstrap.servers=broker1:9092,broker2:9093
+
+  kafka-consumer-perf-test:
+    image: bitnamilegacy/kafka:2.4.1
+    networks:
+      - e2e
+    depends_on:
+      - kafka-producer-perf-test
+    command:
+      - bash
+      - -c
+      - >
+        kafka-consumer-perf-test.sh --broker-list broker1:9092,broker2:9093 --topic perftest --messages 100000
+
+  otel-collector:
+    image: otel/opentelemetry-collector:${OTEL_COLLECTOR_VERSION}
+    networks:
+      - e2e
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ../../../../skywalking/test/e2e-v2/cases/kafka/kafka-monitoring/otel-collector-config.yaml:/etc/otel-collector-config.yaml
+    expose:
+      - 55678
+    depends_on:
+      - broker1
+      - broker2
+
+networks:
+  e2e:

--- a/test/e2e/cases/kafka-monitoring/e2e.yaml
+++ b/test/e2e/cases/kafka-monitoring/e2e.yaml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+setup:
+  env: compose
+  file: docker-compose.yml
+  timeout: 20m
+  init-system-environment: ../../script/env
+  steps:
+    - name: set PATH
+      command: export PATH=/tmp/skywalking-infra-e2e/bin:$PATH
+    - name: install yq
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh yq
+    - name: install swctl
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh swctl
+
+verify:
+  retry:
+    count: 20
+    interval: 10s
+  cases:
+    - includes:
+        - ../../../../skywalking/test/e2e-v2/cases/kafka/kafka-monitoring/kafka-cases.yaml

--- a/test/e2e/cases/mongodb/docker-compose.yml
+++ b/test/e2e/cases/mongodb/docker-compose.yml
@@ -1,0 +1,119 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+services:
+  banyandb:
+    extends:
+      file: ../../../../skywalking/test/e2e-v2/script/docker-compose/base-compose.yml
+      service: banyandb
+    ports:
+      - 17912
+
+  oap:
+    image: skywalking-oap-native:latest
+    expose:
+      - 11800
+      - 12800
+    networks:
+      - e2e
+    ports:
+      - 12800
+    environment:
+      SW_HEALTH_CHECKER: default
+      SW_STORAGE_BANYANDB_TARGETS: banyandb:17912
+      SW_CONFIGURATION: none
+    depends_on:
+      banyandb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "nc -nz 127.0.0.1 11800 || exit 1"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  mongodb-1: &mongodb
+    image: mongo:6.0.8
+    networks:
+      - e2e
+    command: mongod --replSet rs1 --shardsvr --port 27017
+    healthcheck:
+      test: [ "CMD", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/27017" ]
+      interval: 10s
+      timeout: 10s
+      retries: 120
+  mongodb-2: *mongodb
+  mongodb-repl-setup:
+    image: mongo:6.0.8
+    networks:
+      - e2e
+    depends_on:
+      mongodb-1:
+        condition: service_healthy
+      mongodb-2:
+        condition: service_healthy
+    volumes:
+      - ../../../../skywalking/test/e2e-v2/cases/mongodb/setup.sh:/setup.sh
+    entrypoint: [ "bash", "/setup.sh" ]
+  mongodb-exporter-1:
+    image: percona/mongodb_exporter:0.39
+    expose:
+      - 9216
+    networks:
+      - e2e
+    depends_on:
+      mongodb-1:
+        condition: service_healthy
+    command:
+      - '--mongodb.uri=mongodb://mongodb-1:27017'
+      - '--discovering-mode'
+      - '--compatible-mode'
+      - '--collector.dbstats'
+      - '--collector.diagnosticdata'
+      - '--collector.replicasetstatus'
+  mongodb-exporter-2:
+    image: percona/mongodb_exporter:0.39
+    expose:
+      - 9216
+    networks:
+      - e2e
+    depends_on:
+      mongodb-2:
+        condition: service_healthy
+    command:
+      - '--mongodb.uri=mongodb://mongodb-2:27017'
+      - '--discovering-mode'
+      - '--compatible-mode'
+      - '--collector.dbstats'
+      - '--collector.diagnosticdata'
+      - '--collector.replicasetstatus'
+  otel-collector:
+    image: otel/opentelemetry-collector:${OTEL_COLLECTOR_VERSION}
+    networks:
+      - e2e
+    command: [ "--config=/etc/otel-collector-config.yaml" ]
+    volumes:
+      - ../../../../skywalking/test/e2e-v2/cases/mongodb/otel-collector-config.yaml:/etc/otel-collector-config.yaml
+    expose:
+      - 55678
+    depends_on:
+      oap:
+        condition: service_healthy
+      mongodb-exporter-1:
+        condition: service_started
+      mongodb-exporter-2:
+        condition: service_started
+
+networks:
+  e2e:

--- a/test/e2e/cases/mongodb/e2e.yaml
+++ b/test/e2e/cases/mongodb/e2e.yaml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+setup:
+  env: compose
+  file: docker-compose.yml
+  timeout: 20m
+  init-system-environment: ../../script/env
+  steps:
+    - name: set PATH
+      command: export PATH=/tmp/skywalking-infra-e2e/bin:$PATH
+    - name: install yq
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh yq
+    - name: install swctl
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh swctl
+
+verify:
+  retry:
+    count: 60
+    interval: 3s
+  cases:
+    - includes:
+        - ../../../../skywalking/test/e2e-v2/cases/mongodb/mongodb-cases.yaml

--- a/test/e2e/cases/mtls/docker-compose.yml
+++ b/test/e2e/cases/mtls/docker-compose.yml
@@ -1,0 +1,144 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+services:
+  banyandb:
+    extends:
+      file: ../../../../skywalking/test/e2e-v2/script/docker-compose/base-compose.yml
+      service: banyandb
+    ports:
+      - 17912
+
+  oap:
+    image: skywalking-oap-native:latest
+    volumes:
+      - ../../../../skywalking/test/e2e-v2/cases/simple/mtls/server:/skywalking/certs
+    expose:
+      - 11800
+      - 12800
+      - 11811
+    networks:
+      - e2e
+    ports:
+      - 12800
+    environment:
+      SW_HEALTH_CHECKER: default
+      SW_STORAGE_BANYANDB_TARGETS: banyandb:17912
+      SW_CONFIGURATION: none
+      SW_RECEIVER_GRPC_PORT: 11811
+      SW_RECEIVER_GRPC_SSL_ENABLED: "true"
+      SW_RECEIVER_GRPC_SSL_KEY_PATH: /skywalking/certs/server.pem
+      SW_RECEIVER_GRPC_SSL_CERT_CHAIN_PATH: /skywalking/certs/server.crt
+      SW_RECEIVER_GRPC_SSL_TRUSTED_CAS_PATH: /skywalking/certs/ca.crt
+    depends_on:
+      banyandb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "nc -nz 127.0.0.1 11800 || exit 1"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  # Init containers: copy pre-built service JARs into a shared volume
+  provider-jar:
+    image: "ghcr.io/apache/skywalking/e2e-service-provider:${SW_E2E_SERVICE_COMMIT}"
+    entrypoint: ["cp", "/app.jar", "/jars/services_provider.jar"]
+    volumes:
+      - service-jars:/jars
+    networks:
+      - e2e
+
+  consumer-jar:
+    image: "ghcr.io/apache/skywalking/e2e-service-consumer:${SW_E2E_SERVICE_COMMIT}"
+    entrypoint: ["cp", "/app.jar", "/jars/services_consumer.jar"]
+    volumes:
+      - service-jars:/jars
+    networks:
+      - e2e
+
+  provider:
+    image: "ghcr.io/apache/skywalking-java/skywalking-java:${SW_AGENT_JAVA_COMMIT}-java${SW_AGENT_JDK_VERSION}"
+    command: ["java", "-jar", "/jars/services_provider.jar"]
+    volumes:
+      - service-jars:/jars
+      - ../../../../skywalking/test/e2e-v2/cases/simple/mtls/client:/skywalking/agent/certs
+    networks:
+      - e2e
+    expose:
+      - 9090
+    ports:
+      - 9090
+    environment:
+      SW_AGENT_COLLECTOR_BACKEND_SERVICES: oap:11811
+      SW_AGENT_SSL_KEY_PATH: /certs/client.pem
+      SW_AGENT_SSL_CERT_CHAIN_PATH: /certs/client.crt
+      SW_AGENT_SSL_TRUSTED_CA_PATH: /certs/ca.crt
+      SW_LOGGING_OUTPUT: CONSOLE
+      SW_AGENT_NAME: e2e-service-provider
+      SW_AGENT_INSTANCE_NAME: provider1
+      SW_AGENT_COLLECTOR_GET_PROFILE_TASK_INTERVAL: 1
+      SW_AGENT_COLLECTOR_GET_AGENT_DYNAMIC_CONFIG_INTERVAL: 1
+      SW_METER_ACTIVE: 'false'
+    healthcheck:
+      test: ["CMD", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/9090"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+    depends_on:
+      oap:
+        condition: service_healthy
+      provider-jar:
+        condition: service_completed_successfully
+
+  consumer:
+    image: "ghcr.io/apache/skywalking-java/skywalking-java:${SW_AGENT_JAVA_COMMIT}-java${SW_AGENT_JDK_VERSION}"
+    command: ["java", "-jar", "/jars/services_consumer.jar"]
+    volumes:
+      - service-jars:/jars
+      - ../../../../skywalking/test/e2e-v2/cases/simple/mtls/client:/skywalking/agent/certs
+    networks:
+      - e2e
+    expose:
+      - 9092
+    ports:
+      - 9092
+    environment:
+      SW_AGENT_COLLECTOR_BACKEND_SERVICES: oap:11811
+      SW_AGENT_SSL_KEY_PATH: /certs/client.pem
+      SW_AGENT_SSL_CERT_CHAIN_PATH: /certs/client.crt
+      SW_AGENT_SSL_TRUSTED_CA_PATH: /certs/ca.crt
+      SW_LOGGING_OUTPUT: CONSOLE
+      PROVIDER_URL: http://provider:9090
+      SW_AGENT_NAME: e2e-service-consumer
+      SW_AGENT_INSTANCE_NAME: consumer1
+      SW_AGENT_COLLECTOR_GET_PROFILE_TASK_INTERVAL: 1
+      SW_AGENT_COLLECTOR_GET_AGENT_DYNAMIC_CONFIG_INTERVAL: 1
+      SW_METER_ACTIVE: 'false'
+    healthcheck:
+      test: ["CMD", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/9092"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+    depends_on:
+      provider:
+        condition: service_healthy
+      consumer-jar:
+        condition: service_completed_successfully
+
+volumes:
+  service-jars:
+
+networks:
+  e2e:

--- a/test/e2e/cases/mtls/e2e.yaml
+++ b/test/e2e/cases/mtls/e2e.yaml
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+setup:
+  env: compose
+  file: docker-compose.yml
+  timeout: 20m
+  init-system-environment: ../../script/env
+  steps:
+    - name: set PATH
+      command: export PATH=/tmp/skywalking-infra-e2e/bin:$PATH
+    - name: install yq
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh yq
+    - name: install swctl
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh swctl
+
+trigger:
+  action: http
+  interval: 3s
+  times: -1
+  url: http://${consumer_host}:${consumer_9092}/users
+  method: POST
+  body: '{"id":"123","name":"skywalking"}'
+  headers:
+    "Content-Type": "application/json"
+
+verify:
+  retry:
+    count: 20
+    interval: 3s
+  cases:
+    - includes:
+        - ../../../../skywalking/test/e2e-v2/cases/simple/simple-cases.yaml

--- a/test/e2e/cases/pulsar/docker-compose.yml
+++ b/test/e2e/cases/pulsar/docker-compose.yml
@@ -1,0 +1,156 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+services:
+  banyandb:
+    extends:
+      file: ../../../../skywalking/test/e2e-v2/script/docker-compose/base-compose.yml
+      service: banyandb
+    ports:
+      - 17912
+
+  oap:
+    image: skywalking-oap-native:latest
+    expose:
+      - 11800
+      - 12800
+    networks:
+      - e2e
+    ports:
+      - 12800
+    environment:
+      SW_HEALTH_CHECKER: default
+      SW_STORAGE_BANYANDB_TARGETS: banyandb:17912
+      SW_CONFIGURATION: none
+    depends_on:
+      banyandb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "nc -nz 127.0.0.1 11800 || exit 1"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  # Start zookeeper
+  zookeeper:
+    image: zookeeper:3.9.1
+    expose:
+      - 2181
+    networks:
+      - e2e
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+    healthcheck:
+      test: ["CMD", "nc", "-nz", "127.0.0.1", "2181"]
+      interval: 15s
+      timeout: 10s
+      retries: 120
+
+  # Start bookie
+  bookie:
+    image: apachepulsar/pulsar:3.1.1
+    restart: on-failure
+    hostname: bookie
+    networks:
+      - e2e
+    environment:
+      - clusterName=pulsar-cluster
+      - zkServers=zookeeper:2181
+      - metadataServiceUri=metadata-store:zk:zookeeper:2181
+      - advertisedAddress=bookie
+      - BOOKIE_MEM=-Xms512m -Xmx512m -XX:MaxDirectMemorySize=256m
+      - allowLoopback=true
+    depends_on:
+      zookeeper:
+        condition: service_healthy
+    expose:
+      - 8000
+    ports:
+      - "8000:8000"
+    command: bash -c "bin/apply-config-from-env.py conf/bookkeeper.conf && exec bin/pulsar bookie"
+    healthcheck:
+      test: ["CMD", "nc", "-nz", "127.0.0.1", "8000"]
+      interval: 15s
+      timeout: 10s
+      retries: 120
+
+  # Start broker
+  broker:
+    image: apachepulsar/pulsar:3.1.1
+    restart: on-failure
+    hostname: broker
+    networks:
+      - e2e
+    environment:
+      - metadataStoreUrl=zk:zookeeper:2181
+      - zookeeperServers=zookeeper:2181
+      - clusterName=pulsar-cluster
+      - managedLedgerDefaultEnsembleSize=1
+      - managedLedgerDefaultWriteQuorum=1
+      - managedLedgerDefaultAckQuorum=1
+      - advertisedAddress=broker
+      - advertisedListeners=external:pulsar://127.0.0.1:6650
+      - PULSAR_MEM=-Xms512m -Xmx512m -XX:MaxDirectMemorySize=256m
+    depends_on:
+      zookeeper:
+        condition: service_healthy
+    expose:
+      - 8080
+      - 6650
+    ports:
+      - "6650:6650"
+      - "8080:8080"
+    command: bash -c "bin/pulsar initialize-cluster-metadata --cluster pulsar-cluster --zookeeper zookeeper:2181 --configuration-store zookeeper:2181 --web-service-url http://broker:8080 --broker-service-url pulsar://broker:6650 && bin/apply-config-from-env.py conf/broker.conf && exec bin/pulsar broker"
+    healthcheck:
+      test: ["CMD", "nc", "-nz", "127.0.0.1", "8080"]
+      interval: 15s
+      timeout: 10s
+      retries: 120
+
+  consume-perf:
+    image: apachepulsar/pulsar:3.1.1
+    networks:
+      - e2e
+    depends_on:
+      broker:
+        condition: service_healthy
+    command: bash -c "bin/pulsar-perf consume -m 100000 my-topic"
+
+  produce-perf:
+    image: apachepulsar/pulsar:3.1.1
+    networks:
+      - e2e
+    depends_on:
+      broker:
+        condition: service_healthy
+      consume-perf:
+        condition: service_started
+    command: bash -c "bin/pulsar-perf produce -m 100000 my-topic"
+
+  otel-collector:
+    image: otel/opentelemetry-collector:${OTEL_COLLECTOR_VERSION}
+    networks:
+      - e2e
+    command: [ "--config=/etc/otel-collector-config.yaml" ]
+    volumes:
+      - ../../../../skywalking/test/e2e-v2/cases/pulsar/otel-collector-config.yaml:/etc/otel-collector-config.yaml
+    expose:
+      - 55678
+    depends_on:
+      oap:
+        condition: service_healthy
+
+networks:
+  e2e:

--- a/test/e2e/cases/pulsar/e2e.yaml
+++ b/test/e2e/cases/pulsar/e2e.yaml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+setup:
+  env: compose
+  file: docker-compose.yml
+  timeout: 20m
+  init-system-environment: ../../script/env
+  steps:
+    - name: set PATH
+      command: export PATH=/tmp/skywalking-infra-e2e/bin:$PATH
+    - name: install yq
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh yq
+    - name: install swctl
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh swctl
+
+verify:
+  retry:
+    count: 60
+    interval: 3s
+  cases:
+    - includes:
+        - ../../../../skywalking/test/e2e-v2/cases/pulsar/pulsar-cases.yaml

--- a/test/e2e/cases/rabbitmq/docker-compose.yml
+++ b/test/e2e/cases/rabbitmq/docker-compose.yml
@@ -1,0 +1,210 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+services:
+  banyandb:
+    extends:
+      file: ../../../../skywalking/test/e2e-v2/script/docker-compose/base-compose.yml
+      service: banyandb
+    ports:
+      - 17912
+
+  oap:
+    image: skywalking-oap-native:latest
+    expose:
+      - 11800
+      - 12800
+    networks:
+      - e2e
+    ports:
+      - 12800
+    environment:
+      SW_HEALTH_CHECKER: default
+      SW_STORAGE_BANYANDB_TARGETS: banyandb:17912
+      SW_CONFIGURATION: none
+    depends_on:
+      banyandb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "nc -nz 127.0.0.1 11800 || exit 1"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  rmq0: &rabbitmq
+    image: rabbitmq:3.11.14-management
+    networks:
+      - "e2e"
+    ports:
+      - "15673:15672"
+      - "15693:15692"
+    cap_add:
+      - ALL
+    hostname: rmq0
+    environment:
+      RABBITMQ_ERLANG_COOKIE: rabbitmq-prometheus
+    volumes:
+      - ../../../../skywalking/test/e2e-v2/cases/rabbitmq/rabbitmq-overview.conf:/etc/rabbitmq/rabbitmq.conf:ro
+      - ../../../../skywalking/test/e2e-v2/cases/rabbitmq/rabbitmq-overview-definitions.json:/etc/rabbitmq/rabbitmq-definitions.json:ro
+    ulimits:
+      nofile:
+        soft: 2000
+        hard: 2000
+  rmq1:
+    <<: *rabbitmq
+    hostname: rmq1
+    ports:
+      - "15674:15672"
+      - "15694:15692"
+  rmq2:
+    <<: *rabbitmq
+    hostname: rmq2
+    ports:
+      - "15675:15672"
+      - "15695:15692"
+
+  # The following services are used for mocking test data
+  basic-get:
+    image: &perf-test-image pivotalrabbitmq/perf-test:2.15.0-ubuntu
+    networks:
+      - "e2e"
+    environment:
+      URI: "amqp://guest:guest@rmq0:5672/%2f"
+      QUEUE: basic-get
+      ROUTING_KEY: basic-get
+      VARIABLE_RATE: "1:1,0:30"
+      POLLING: "true"
+      POLLING_INTERVAL: 5000
+      AUTOACK: "false"
+      SERVERS_STARTUP_TIMEOUT: &startup_timeout 60
+      METRICS_PROMETHEUS: "true"
+  basic-get-auto:
+    image: *perf-test-image
+    networks:
+      - "e2e"
+    environment:
+      URI: "amqp://guest:guest@rmq0:5672/%2f"
+      QUEUE: basic-get
+      ROUTING_KEY: basic-get
+      PRODUCERS: 0
+      POLLING: "true"
+      POLLING_INTERVAL: 5000
+      AUTOACK: "true"
+      SERVERS_STARTUP_TIMEOUT: *startup_timeout
+      METRICS_PROMETHEUS: "true"
+  greedy-consumer:
+    image: *perf-test-image
+    networks:
+      - "e2e"
+    environment:
+      URI: "amqp://guest:guest@rmq0:5672/%2f"
+      QUEUE: greedy-consumer
+      ROUTING_KEY: greedy-consumer
+      VARIABLE_RATE: "100:20,0:20"
+      CONSUMER_RATE: 50
+      QOS: 2000
+      AUTOACK: "false"
+      SERVERS_STARTUP_TIMEOUT: *startup_timeout
+      METRICS_PROMETHEUS: "true"
+  publisher-confirms:
+    image: *perf-test-image
+    networks:
+      - "e2e"
+    environment:
+      URI: "amqp://guest:guest@rmq1:5672/%2f"
+      QUEUE: publisher-confirms
+      ROUTING_KEY: publisher-confirms
+      AUTOACK: "true"
+      VARIABLE_RATE: "12:30,25:30,50:30,100:30"
+      CONFIRM: 1
+      CONFIRM_TIMEOUT: 1
+      SERVERS_STARTUP_TIMEOUT: *startup_timeout
+      METRICS_PROMETHEUS: "true"
+  slow-consumer-persistent:
+    image: *perf-test-image
+    networks:
+      - "e2e"
+    environment:
+      URI: "amqp://guest:guest@rmq1:5672/%2f"
+      QUEUE: ha3-slow-consumer-persistent
+      ROUTING_KEY: slow-consumer-persistent
+      QUEUE_ARGS: x-max-length=10000
+      FLAG: persistent
+      AUTO_DELETE: "false"
+      SIZE: 51200
+      VARIABLE_RATE: "100:20,0:20"
+      CONSUMER_RATE: 50
+      QOS: 50
+      AUTOACK: "false"
+      SERVERS_STARTUP_TIMEOUT: *startup_timeout
+      METRICS_PROMETHEUS: "true"
+  nack:
+    image: *perf-test-image
+    networks:
+      - "e2e"
+    entrypoint: []
+    command: /bin/bash -c "while true; do bin/runjava com.rabbitmq.perf.PerfTest; sleep 10; done"
+    environment:
+      TIME: 60
+      URI: "amqp://guest:guest@rmq2:5672/%2f"
+      VARIABLE_RATE: "1:10,0:20"
+      QUEUE: nack
+      QUEUE_ARGS: x-max-length=100
+      ROUTING_KEY: nack
+      AUTOACK: "false"
+      NACK: "true"
+      QOS: 5
+      CONSUMER_LATENCY: 3000000
+      SERVERS_STARTUP_TIMEOUT: *startup_timeout
+      METRICS_PROMETHEUS: "true"
+  unroutable-return:
+    image: *perf-test-image
+    networks:
+      - "e2e"
+    environment:
+      URI: "amqp://guest:guest@rmq2:5672/%2f"
+      VARIABLE_RATE: "2:30,4:30,10:30"
+      VARIABLE_SIZE: "100:30,200:30"
+      CONSUMERS: 0
+      FLAG: mandatory
+      SERVERS_STARTUP_TIMEOUT: *startup_timeout
+      METRICS_PROMETHEUS: "true"
+  unroutable-drop:
+    image: *perf-test-image
+    networks:
+      - "e2e"
+    environment:
+      URI: "amqp://guest:guest@rmq2:5672/%2f"
+      VARIABLE_RATE: "5:30,10:30,20:30"
+      VARIABLE_SIZE: "100:30,200:30"
+      CONSUMERS: 0
+      SERVERS_STARTUP_TIMEOUT: *startup_timeout
+      METRICS_PROMETHEUS: "true"
+
+  otel-collector:
+    image: otel/opentelemetry-collector:${OTEL_COLLECTOR_VERSION}
+    networks:
+      - e2e
+    command: [ "--config=/etc/otel-collector-config.yaml" ]
+    volumes:
+      - ../../../../skywalking/test/e2e-v2/cases/rabbitmq/otel-collector-config.yaml:/etc/otel-collector-config.yaml
+    expose:
+      - 55678
+    depends_on:
+      oap:
+        condition: service_healthy
+
+networks:
+  e2e:

--- a/test/e2e/cases/rabbitmq/e2e.yaml
+++ b/test/e2e/cases/rabbitmq/e2e.yaml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+setup:
+  env: compose
+  file: docker-compose.yml
+  timeout: 20m
+  init-system-environment: ../../script/env
+  steps:
+    - name: set PATH
+      command: export PATH=/tmp/skywalking-infra-e2e/bin:$PATH
+    - name: install yq
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh yq
+    - name: install swctl
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh swctl
+
+verify:
+  retry:
+    count: 60
+    interval: 3s
+  cases:
+    - includes:
+        - ../../../../skywalking/test/e2e-v2/cases/rabbitmq/rabbitmq-cases.yaml

--- a/test/e2e/cases/redis/docker-compose.yml
+++ b/test/e2e/cases/redis/docker-compose.yml
@@ -1,0 +1,137 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+services:
+  banyandb:
+    extends:
+      file: ../../../../skywalking/test/e2e-v2/script/docker-compose/base-compose.yml
+      service: banyandb
+    ports:
+      - 17912
+
+  oap:
+    image: skywalking-oap-native:latest
+    expose:
+      - 11800
+      - 12800
+    networks:
+      - e2e
+    ports:
+      - 12800
+    environment:
+      SW_HEALTH_CHECKER: default
+      SW_STORAGE_BANYANDB_TARGETS: banyandb:17912
+      SW_CONFIGURATION: none
+      TZ: Asia/Shanghai
+      SW_CORE_TOPN_REPORT_PERIOD: 2
+    depends_on:
+      banyandb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "nc -nz 127.0.0.1 11800 || exit 1"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  redis_1: &redis
+    image: redis:6.0
+    networks:
+      - e2e
+    volumes:
+      - ../../../../skywalking/test/e2e-v2/cases/redis/redis-exporter/redis.conf:/etc/redis/redis.conf
+    ports:
+      - 6379
+    command:
+      redis-server /etc/redis/redis.conf
+    healthcheck:
+      test: ["CMD", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/6379"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+  redis_2:
+    <<: *redis
+  redis_3:
+    <<: *redis
+
+  redis_mock:
+    <<: *redis
+    volumes:
+      - ../../../../skywalking/test/e2e-v2/cases/redis/redis-exporter/redis.conf:/etc/redis/redis.conf
+      - ../../../../skywalking/test/e2e-v2/cases/redis/redis-exporter/mock.txt:/etc/redis/mock.txt
+    depends_on:
+      - otel-collector
+      - redis_1
+      - redis_exporter_1
+    entrypoint: bash
+    command:
+      - -c
+      - "cat /etc/redis/mock.txt | redis-cli -h redis_1 -p 6379 &&  redis-server /etc/redis/redis.conf "
+
+  redis_exporter_1: &redis_exporter
+    image: oliver006/redis_exporter:v1.48.0-alpine
+    networks:
+      - e2e
+    ports:
+      - 9121
+    environment:
+      - REDIS_ADDR=redis_1:6379
+  redis_exporter_2:
+    <<: *redis_exporter
+    ports:
+      - 9121
+    environment:
+      - REDIS_ADDR=redis_2:6379
+  redis_exporter_3:
+    <<: *redis_exporter
+    environment:
+      - REDIS_ADDR=redis_3:6379
+
+  otel-collector:
+    image: otel/opentelemetry-collector:${OTEL_COLLECTOR_VERSION}
+    networks:
+      - e2e
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ../../../../skywalking/test/e2e-v2/cases/redis/redis-exporter/otel-collector-config.yaml:/etc/otel-collector-config.yaml
+    expose:
+      - 55678
+    depends_on:
+      oap:
+        condition: service_healthy
+
+  fluentbit:
+    image: fluent/fluent-bit:1.9
+    environment:
+      - TZ=Asia/Shanghai
+    volumes:
+      - ../../../../skywalking/test/e2e-v2/cases/redis/redis-exporter/scripts:/scripts
+      - ../../../../skywalking/test/e2e-v2/cases/redis/redis-exporter/fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf
+      - ../../../../skywalking/test/e2e-v2/cases/redis/redis-exporter/fluent-bit-parser.conf:/fluent-bit/etc/fluent-bit-parser.conf
+      - ../../../../skywalking/test/e2e-v2/cases/redis/redis-exporter/fluent-bit-script.lua:/fluent-bit/etc/fluent-bit-script.lua
+    networks:
+      - e2e
+    depends_on:
+      - slowlog
+
+  slowlog:
+    image: redis:6.0
+    volumes:
+      - ../../../../skywalking/test/e2e-v2/cases/redis/redis-exporter/scripts:/scripts
+    networks:
+      - e2e
+    command: sh -c "chmod 777 /scripts/start.sh /scripts/slowlog.sh /scripts/slowlog.log && /scripts/start.sh"
+
+networks:
+  e2e:

--- a/test/e2e/cases/redis/e2e.yaml
+++ b/test/e2e/cases/redis/e2e.yaml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+setup:
+  env: compose
+  file: docker-compose.yml
+  timeout: 20m
+  init-system-environment: ../../script/env
+  steps:
+    - name: set PATH
+      command: export PATH=/tmp/skywalking-infra-e2e/bin:$PATH
+    - name: install yq
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh yq
+    - name: install swctl
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh swctl
+
+verify:
+  retry:
+    count: 60
+    interval: 3s
+  cases:
+    - includes:
+        - ../../../../skywalking/test/e2e-v2/cases/redis/redis-cases.yaml

--- a/test/e2e/cases/rocketmq/docker-compose.yml
+++ b/test/e2e/cases/rocketmq/docker-compose.yml
@@ -1,0 +1,135 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+services:
+  banyandb:
+    extends:
+      file: ../../../../skywalking/test/e2e-v2/script/docker-compose/base-compose.yml
+      service: banyandb
+    ports:
+      - 17912
+
+  oap:
+    image: skywalking-oap-native:latest
+    expose:
+      - 11800
+      - 12800
+    networks:
+      - e2e
+    ports:
+      - 12800
+    environment:
+      SW_HEALTH_CHECKER: default
+      SW_STORAGE_BANYANDB_TARGETS: banyandb:17912
+      SW_CONFIGURATION: none
+    depends_on:
+      banyandb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "nc -nz 127.0.0.1 11800 || exit 1"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  rocketmq-namesrv-1:
+    image: apache/rocketmq:4.9.4
+    hostname: rocketmq-namesrv-1
+    ports:
+      - "9876:9876"
+    environment:
+      TZ: Asia/Shanghai
+    command: sh mqnamesrv
+    healthcheck:
+      test: [ "CMD", "nc", "-nz", "127.0.0.1", "9876" ]
+      interval: 15s
+      timeout: 10s
+      retries: 120
+    networks:
+      - e2e
+
+  rocketmq-broker-1:
+    image: apache/rocketmq:4.9.4
+    hostname: rocketmq-broker-1
+    ports:
+      - "10911:10911"
+      - "10909:10909"
+    environment:
+      TZ: Asia/Shanghai
+      NAMESRV_ADDR: "rocketmq-namesrv-1:9876"
+    command: sh mqbroker
+    healthcheck:
+      test: [ "CMD", "nc", "-nz", "127.0.0.1", "10911" ]
+      interval: 15s
+      timeout: 10s
+      retries: 120
+    depends_on:
+      rocketmq-namesrv-1:
+        condition: service_healthy
+    networks:
+      - e2e
+
+  rocketmq-producer-perf-test:
+    image: apache/rocketmq:4.9.4
+    hostname: rocketmq-producer-perf-test
+    environment:
+      TZ: Asia/Shanghai
+      NAMESRV_ADDR: "rocketmq-namesrv-1:9876"
+    command: sh tools.sh org.apache.rocketmq.example.quickstart.Producer
+    depends_on:
+      rocketmq-broker-1:
+        condition: service_healthy
+    networks:
+      - e2e
+
+  rocketmq-consumer-perf-test:
+    image: apache/rocketmq:4.9.4
+    hostname: rocketmq-consumer-perf-test
+    environment:
+      TZ: Asia/Shanghai
+      NAMESRV_ADDR: "rocketmq-namesrv-1:9876"
+    command: sh tools.sh org.apache.rocketmq.example.quickstart.Consumer
+    depends_on:
+      - rocketmq-producer-perf-test
+    networks:
+      - e2e
+
+  rocketmq-exporter:
+    image: apache/rocketmq-exporter:0.0.2
+    hostname: rocketmq-exporter
+    ports:
+      - "5557:5557"
+    environment:
+      TZ: Asia/Shanghai
+      rocketmq.config.namesrvAddr: "rocketmq-namesrv-1:9876"
+    depends_on:
+      - rocketmq-consumer-perf-test
+    networks:
+      - e2e
+
+  otel-collector:
+    image: otel/opentelemetry-collector:${OTEL_COLLECTOR_VERSION}
+    networks:
+      - e2e
+    command: [ "--config=/etc/otel-collector-config.yaml" ]
+    volumes:
+      - ../../../../skywalking/test/e2e-v2/cases/rocketmq/otel-collector-config.yaml:/etc/otel-collector-config.yaml
+    expose:
+      - 55678
+    depends_on:
+      oap:
+        condition: service_healthy
+
+networks:
+  e2e:

--- a/test/e2e/cases/rocketmq/e2e.yaml
+++ b/test/e2e/cases/rocketmq/e2e.yaml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+setup:
+  env: compose
+  file: docker-compose.yml
+  timeout: 20m
+  init-system-environment: ../../script/env
+  steps:
+    - name: set PATH
+      command: export PATH=/tmp/skywalking-infra-e2e/bin:$PATH
+    - name: install yq
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh yq
+    - name: install swctl
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh swctl
+
+verify:
+  retry:
+    count: 60
+    interval: 3s
+  cases:
+    - includes:
+        - ../../../../skywalking/test/e2e-v2/cases/rocketmq/rocketmq-cases.yaml

--- a/test/e2e/script/env
+++ b/test/e2e/script/env
@@ -26,6 +26,12 @@ SW_UPSTREAM_COMMIT=a0cec0ca237792497d2da0b65757d11f58c3f342
 # Last upstream commit that touched test/e2e-v2/java-test-service/
 SW_E2E_SERVICE_COMMIT=5e3b3853f5742f906655f3e332459c74b58cfb43
 
+# OTEL collector version for infrastructure monitoring tests
+OTEL_COLLECTOR_VERSION=0.102.1
+
+# Java agent JDK version for agent-based tests (ssl, mtls)
+SW_AGENT_JDK_VERSION=8
+
 # Not used by distro tests, but defined to silence docker-compose warnings
 # from upstream base-compose.yml which references it for skypredictor service.
 SW_PREDICTOR_COMMIT=54a0197654a3781a6f73ce35146c712af297c994


### PR DESCRIPTION
### Summary

Add 13 remaining e2e test cases to reach near-complete coverage of upstream SkyWalking tests applicable to this distro.

### New test cases

| Case | What it tests |
|------|--------------|
| **mTLS** | Mutual TLS with client certificates (agent ↔ OAP) |
| **RabbitMQ** | RabbitMQ cluster metrics via OTEL collector |
| **RocketMQ** | RocketMQ metrics via OTEL collector |
| **ActiveMQ** | ActiveMQ metrics via JMX exporter + OTEL collector |
| **Pulsar** | Pulsar cluster metrics via OTEL collector |
| **Kafka Monitoring** | Kafka broker metrics via JMX agent + OTEL collector |
| **Redis** | Redis metrics via redis_exporter + OTEL collector |
| **MongoDB** | MongoDB replica set metrics via mongodb_exporter + OTEL collector |
| **Flink** | Flink job/task manager metrics via Prometheus + OTEL collector |
| **AWS DynamoDB** | DynamoDB metrics via mock sender |
| **AWS S3** | S3 metrics via mock sender |
| **AWS EKS** | EKS metrics via mock sender |
| **AWS API Gateway** | API Gateway metrics via mock sender |

All tests reuse upstream configs, OTEL collector configs, case files, and expected data from the `skywalking/` submodule. Only the OAP service is replaced with the native image.

Total e2e test count: 22 → 35.

- [x] License headers valid: `license-eye header check`
- [ ] CI passes