### PR TITLE
Sync upstream to v10.4.0, add GenAI/Envoy AI Gateway/TraceQL support

### DIFF
--- a/.claude/skills/sync-submodule/SKILL.md
+++ b/.claude/skills/sync-submodule/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: sync-submodule
+description: Checklist and steps for syncing the skywalking submodule to a new upstream tag or commit. Covers all required checks and updates.
+---
+
+# Sync SkyWalking Submodule
+
+Checklist for updating the `skywalking/` submodule to a new upstream tag/commit.
+
+## 1. Update Submodule
+
+```bash
+cd skywalking && git fetch origin --tags && git checkout <tag-or-commit>
+```
+
+Verify the upstream `<revision>` in `skywalking/pom.xml` — the Makefile extracts it for `-Dskywalking.version`.
+
+## 2. Install Upstream to Local Maven Repo
+
+```bash
+make init-skywalking
+```
+
+## 3. Analyze Changes
+
+Compare the old and new commits to identify what changed:
+
+```bash
+cd skywalking && git log --oneline <old-commit>..<new-commit>
+```
+
+### Key areas to check for impact
+
+| Area | What to look for |
+|------|-----------------|
+| **OAL engine** (`oal-rt/`) | API changes to `OALEngineV2` |
+| **MAL engine** (`meter-analyzer/`) | API changes to `MALClassGenerator`, new grammar tokens |
+| **LAL engine** (`log-analyzer/`) | API changes to `LALClassGenerator` |
+| **New modules** | New `ModuleDefine`/`ModuleProvider` classes |
+| **New OAL files** | `oal/*.oal` |
+| **New MAL rules** | `otel-rules/`, `meter-analyzer-config/`, `log-mal-rules/`, `envoy-metrics-rules/`, `telegraf-rules/`, `zabbix-rules/` |
+| **New LAL rules** | `lal/*.yaml` |
+| **Same-FQCN files changed** | Upstream versions of files we replace in `oap-libs-for-graalvm/` |
+| **New config fields** | Changes to `ModuleConfig` subclasses |
+| **application.yml** | New module sections, new config properties |
+| **pom.xml deps** | New module artifacts, version bumps |
+
+## 4. Required Updates (Checklist)
+
+### Module wiring (if new modules added)
+
+- [ ] Add dependency to root `pom.xml` `<dependencyManagement>`
+- [ ] Add dependency to `oap-graalvm-server/pom.xml` `<dependencies>`
+- [ ] Register module+provider in `GraalVMOAPServerStartUp.java`
+- [ ] Add `(moduleName, providerName)` pair to `AcceptedModules.java`
+- [ ] Add module config section to `application.yml`
+
+### Config handling (if new ModuleConfig classes)
+
+- [ ] Re-run config-generator to regenerate `YamlConfigLoaderUtils.java` and `module-config-classes.txt`:
+  ```bash
+  ./mvnw -pl build-tools/build-common,build-tools/config-generator install -DskipTests -Dskywalking.version=<version>
+  ./mvnw -pl build-tools/config-generator exec:java \
+    -Dexec.args="oap-graalvm-server/src/main/java/org/apache/skywalking/oap/server/library/util/YamlConfigLoaderUtils.java build-tools/precompiler/src/main/resources/META-INF/module-config-classes.txt" \
+    -Dskywalking.version=<version>
+  ```
+- [ ] If config class has no `@Setter` at class level, create same-FQCN replacement in `oap-libs-for-graalvm/` with `@Setter` added
+- [ ] Add shade exclusion for replaced config class
+
+### OAL changes (if new .oal files or scopes)
+
+- [ ] New OAL files are auto-discovered via `OALDefine` SPI — verify in precompiler output
+- [ ] Add generated metrics + builder classes to `reachability-metadata.json` in `oap-graalvm-native`
+- [ ] Verify with: `jar tf build-tools/precompiler/target/precompiler-*-generated.jar | grep "oal/rt"`
+
+### MAL/LAL changes (if new rule files)
+
+- [ ] New MAL rules under `otel-rules/` with glob `**/*` are auto-compiled by precompiler
+- [ ] New LAL rules must be added to `lalFiles` in `application.yml`
+- [ ] Update `enabledOtelMetricsRules` in `application.yml` for new otel rule directories
+- [ ] Create MAL comparison tests in `oap-graalvm-server/src/test/.../mal/`
+
+### Inventory updates
+
+- [ ] Add new provider to `provider-inventory.properties`
+- [ ] Add new rule files to `rule-file-inventory.properties`
+
+### Distribution packaging
+
+- [ ] Add runtime config files (not DSL scripts) to `distribution.xml` and `native-distribution.xml`
+- [ ] Update `docs/distro-policy.md` module table
+- [ ] Update `docs/version-mapping.md`
+
+### E2E test environment
+
+- [ ] Update `test/e2e/script/env`:
+  - `SW_UPSTREAM_COMMIT` — submodule HEAD
+  - `SW_E2E_SERVICE_COMMIT` — last commit touching `test/e2e-v2/java-test-service/`
+  - `SW_BANYANDB_COMMIT` — match upstream `test/e2e-v2/script/env`
+  - `SW_AGENT_JAVA_COMMIT` — match upstream
+- [ ] Add new e2e test cases if upstream added new features with e2e tests
+- [ ] Add new test entries to `.github/workflows/ci.yml` matrix
+
+### Same-FQCN replacement staleness
+
+- [ ] Run `ReplacementClassStalenessTest` — if upstream changed files we replace, update replacements
+- [ ] Run `PrecompiledYamlStalenessTest` — update SHA-256 hashes for changed YAML files
+
+## 5. Build & Test
+
+```bash
+make compile          # Compile everything
+make test             # Run all 1300+ tests
+```
+
+## 6. Native Image Verification
+
+```bash
+make native-image-macos   # Cross-compile for Linux (on macOS)
+make docker-native        # Build Docker image
+docker tag skywalking-oap-native skywalking-oap-native:latest
+
+# Run e2e smoke test
+e2e run -c test/e2e/cases/simple-java-agent/e2e.yaml
+```
+
+Check OAP logs for reflection errors:
+```bash
+docker logs <container> 2>&1 | grep "ERROR\|NoSuchMethodException\|ClassNotFoundException"
+```
+
+## 7. Common Pitfalls
+
+- **Reflection errors at native image runtime**: New classes instantiated via `Class.forName().newInstance()` need entries in `reflect-config.json` or `reachability-metadata.json`
+- **Config loading failures**: New `ModuleConfig` subclasses need config-generator regeneration AND may need `@Setter` same-FQCN replacement
+- **Missing config files**: Runtime config files (non-DSL) must be in distribution assembly descriptors
+- **OAL builder registration**: OAL-generated builder classes need constructor entries in `reachability-metadata.json`
+- **Config-generator runs against upstream classpath**: Setter checks see upstream classes (no `@Setter`), not our for-graalvm replacements — the generator trusts that for-graalvm modules will provide setters

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,8 +376,10 @@ jobs:
             case: mqe
           - name: Virtual GenAI
             case: virtual-genai
-          - name: Envoy AI Gateway
-            case: envoy-ai-gateway
+          # Envoy AI Gateway: requires ~400MB Ollama model download at runtime,
+          # not practical for CI. Run manually. Upstream also doesn't run this in CI.
+          # - name: Envoy AI Gateway
+          #   case: envoy-ai-gateway
           - name: TraceQL SkyWalking
             case: traceql-skywalking
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,6 +374,12 @@ jobs:
             case: so11y
           - name: MQE
             case: mqe
+          - name: Virtual GenAI
+            case: virtual-genai
+          - name: Envoy AI Gateway
+            case: envoy-ai-gateway
+          - name: TraceQL SkyWalking
+            case: traceql-skywalking
     steps:
       - name: Checkout with submodules
         uses: actions/checkout@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
           fi
 
       - name: Set up GraalVM JDK 25
-        uses: graalvm/setup-graalvm@eec48106e0bf45f2976c2ff0c3e22395cced8243  # v1
+        uses: graalvm/setup-graalvm@f744c72a42b1995d7b0cbc314bde4bace7ac1fe1  # v1.5.0
         with:
           java-version: '25'
           distribution: 'graalvm'
@@ -120,7 +120,7 @@ jobs:
           submodules: recursive
 
       - name: Set up GraalVM JDK 25
-        uses: graalvm/setup-graalvm@eec48106e0bf45f2976c2ff0c3e22395cced8243  # v1
+        uses: graalvm/setup-graalvm@f744c72a42b1995d7b0cbc314bde4bace7ac1fe1  # v1.5.0
         with:
           java-version: '25'
           distribution: 'graalvm'
@@ -174,7 +174,7 @@ jobs:
           submodules: recursive
 
       - name: Set up GraalVM JDK 25
-        uses: graalvm/setup-graalvm@eec48106e0bf45f2976c2ff0c3e22395cced8243  # v1
+        uses: graalvm/setup-graalvm@f744c72a42b1995d7b0cbc314bde4bace7ac1fe1  # v1.5.0
         with:
           java-version: '25'
           distribution: 'graalvm'

--- a/build-tools/build-common/src/main/java/org/apache/skywalking/oap/server/buildtools/common/AcceptedModules.java
+++ b/build-tools/build-common/src/main/java/org/apache/skywalking/oap/server/buildtools/common/AcceptedModules.java
@@ -56,6 +56,7 @@ public final class AcceptedModules {
         new ModuleProviderPair("agent-analyzer", "default"),
         new ModuleProviderPair("log-analyzer", "default"),
         new ModuleProviderPair("event-analyzer", "default"),
+        new ModuleProviderPair("gen-ai-analyzer", "default"),
         // Receivers
         new ModuleProviderPair("receiver-sharing-server", "default"),
         new ModuleProviderPair("receiver-register", "default"),

--- a/build-tools/config-generator/src/main/java/org/apache/skywalking/oap/server/buildtools/config/ConfigInitializerGenerator.java
+++ b/build-tools/config-generator/src/main/java/org/apache/skywalking/oap/server/buildtools/config/ConfigInitializerGenerator.java
@@ -196,6 +196,10 @@ public class ConfigInitializerGenerator {
         // Collect all imports needed for config classes and their field types
         TreeMap<String, String> imports = new TreeMap<>();
         for (var entry : configClasses.entrySet()) {
+            // Skip imports for config classes with no fields (not used in generated code)
+            if (entry.getValue().fields.isEmpty()) {
+                continue;
+            }
             String fqcn = entry.getKey();
             if (fqcn.contains("$")) {
                 String enclosing = fqcn.substring(0, fqcn.indexOf('$'));

--- a/build-tools/precompiler/src/main/resources/META-INF/module-config-classes.txt
+++ b/build-tools/precompiler/src/main/resources/META-INF/module-config-classes.txt
@@ -1,3 +1,6 @@
+org.apache.skywalking.oap.analyzer.genai.config.GenAIConfig
+org.apache.skywalking.oap.analyzer.genai.config.GenAIConfig$Model
+org.apache.skywalking.oap.analyzer.genai.config.GenAIConfig$Provider
 org.apache.skywalking.oap.log.analyzer.v2.provider.LogAnalyzerModuleConfig
 org.apache.skywalking.oap.query.debug.StatusQueryConfig
 org.apache.skywalking.oap.query.graphql.GraphQLQueryConfig

--- a/changes/changes.md
+++ b/changes/changes.md
@@ -4,7 +4,10 @@
 
 ### Upstream Sync
 
-- Sync SkyWalking submodule to upstream commit `726ebcc321` (MAL v2 companion class closures).
+- Sync SkyWalking submodule to upstream v10.4.0 release tag.
+- Add `gen-ai-analyzer` module: GenAI provider/model metrics from virtual-gen-ai.oal.
+- Add Envoy AI Gateway MAL/LAL rules and config.
+- Add TraceQL config properties: `lookback`, `zipkinTracesListResultTags`, `skywalkingTracesListResultTags`.
 
 ### GraalVM Native Image Compatibility
 
@@ -24,6 +27,10 @@
 - Add OTLP Traces e2e test case (OpenTelemetry trace ingestion via Zipkin API).
 - Add Virtual MQ e2e test case (Kafka-instrumented virtual MQ layer metrics).
 - Add Kafka Exporter e2e test case (trace and log export to Kafka).
+- Add Virtual GenAI e2e test case (GenAI provider/model metrics via Spring AI + Java agent).
+- Add Envoy AI Gateway e2e test case (ENVOY_AI_GATEWAY layer metrics/logs via OTLP).
+- Add TraceQL SkyWalking e2e test case (Tempo API with SkyWalking native trace datasource).
+- Add Envoy AI Gateway MAL comparison tests (34 tests for gateway-service and gateway-instance rules).
 - Add Self-Observability e2e test case (OAP Prometheus telemetry via OTEL collector).
 - Add MQE e2e test case (Metrics Query Engine expression evaluation with baseline).
 

--- a/docs/distro-policy.md
+++ b/docs/distro-policy.md
@@ -17,7 +17,7 @@ Build and package Apache SkyWalking OAP server as a GraalVM native image on JDK 
 | **Cluster** | ClusterModule | Standalone, Kubernetes |
 | **Configuration** | ConfigurationModule | Kubernetes |
 | **Receivers** | SharingServerModule, TraceModule, JVMModule, MeterReceiverModule, LogModule, RegisterModule, ProfileModule, BrowserModule, EventModule, OtelMetricReceiverModule, MeshReceiverModule, EnvoyMetricReceiverModule, ZipkinReceiverModule, ZabbixReceiverModule, TelegrafReceiverModule, AWSFirehoseReceiverModule, CiliumFetcherModule, EBPFReceiverModule, AsyncProfilerModule, PprofModule, CLRModule, ConfigurationDiscoveryModule, KafkaFetcherModule | default providers |
-| **Analyzers** | AnalyzerModule, LogAnalyzerModule, EventAnalyzerModule | default providers |
+| **Analyzers** | AnalyzerModule, LogAnalyzerModule, EventAnalyzerModule, GenAIAnalyzerModule | default providers |
 | **Query** | QueryModule (GraphQL), PromQLModule, LogQLModule, TraceQLModule, ZipkinQueryModule, StatusQueryModule | default providers |
 | **Alarm** | AlarmModule | default |
 | **Telemetry** | TelemetryModule | Prometheus |

--- a/docs/version-mapping.md
+++ b/docs/version-mapping.md
@@ -8,7 +8,7 @@ Otherwise, it is shown as `{commit-id}-SNAPSHOT` indicating a development build 
 <!-- DOC-CHECK: version-mapping-table -->
 | Distro Version | Apache SkyWalking Version |
 |---|---|
-| 0.3.0-SNAPSHOT (dev) | `726ebcc321db`-SNAPSHOT |
+| 0.3.0-SNAPSHOT (dev) | 10.4.0 |
 | 0.2.1 | `64a1795d8a58`-SNAPSHOT |
 | 0.2.0 | `64a1795d8a58`-SNAPSHOT |
 | 0.1.1 | `64a1795d8a58`-SNAPSHOT |

--- a/oap-graalvm-native/src/main/assembly/native-distribution.xml
+++ b/oap-graalvm-native/src/main/assembly/native-distribution.xml
@@ -81,6 +81,7 @@
                 <include>metadata-service-mapping.yaml</include>
                 <include>service-apdex-threshold.yml</include>
                 <include>trace-sampling-policy-settings.yml</include>
+                <include>gen-ai-config.yml</include>
             </includes>
         </fileSet>
         <!-- LICENSE, NOTICE, and third-party licenses from upstream dist-material -->

--- a/oap-graalvm-native/src/main/resources/META-INF/native-image/org.apache.skywalking/oap-graalvm-native/reachability-metadata.json
+++ b/oap-graalvm-native/src/main/resources/META-INF/native-image/org.apache.skywalking/oap-graalvm-native/reachability-metadata.json
@@ -12983,6 +12983,160 @@
       "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.ServiceThroughputSentMetrics"
     },
     {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.GenAiModelAvgEstimatedCostMetrics"
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.GenAiModelCallCpmMetrics"
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.GenAiModelInputTokensAvgMetrics"
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.GenAiModelInputTokensSumMetrics"
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.GenAiModelLatencyAvgMetrics"
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.GenAiModelLatencyPercentileMetrics"
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.GenAiModelOutputTokensAvgMetrics"
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.GenAiModelOutputTokensSumMetrics"
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.GenAiModelSlaMetrics"
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.GenAiModelTotalEstimatedCostMetrics"
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.GenAiModelTtftAvgMetrics"
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.GenAiModelTtftPercentileMetrics"
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.GenAiProviderAvgEstimatedCostMetrics"
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.GenAiProviderCpmMetrics"
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.GenAiProviderInputTokensAvgMetrics"
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.GenAiProviderInputTokensSumMetrics"
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.GenAiProviderLatencyPercentileMetrics"
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.GenAiProviderOutputTokensAvgMetrics"
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.GenAiProviderOutputTokensSumMetrics"
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.GenAiProviderRespTimeMetrics"
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.GenAiProviderSlaMetrics"
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.GenAiProviderTotalEstimatedCostMetrics"
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.builder.GenAiModelAvgEstimatedCostMetricsBuilder",
+      "methods": [{ "name": "<init>", "parameterTypes": [] }]
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.builder.GenAiModelCallCpmMetricsBuilder",
+      "methods": [{ "name": "<init>", "parameterTypes": [] }]
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.builder.GenAiModelInputTokensAvgMetricsBuilder",
+      "methods": [{ "name": "<init>", "parameterTypes": [] }]
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.builder.GenAiModelInputTokensSumMetricsBuilder",
+      "methods": [{ "name": "<init>", "parameterTypes": [] }]
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.builder.GenAiModelLatencyAvgMetricsBuilder",
+      "methods": [{ "name": "<init>", "parameterTypes": [] }]
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.builder.GenAiModelLatencyPercentileMetricsBuilder",
+      "methods": [{ "name": "<init>", "parameterTypes": [] }]
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.builder.GenAiModelOutputTokensAvgMetricsBuilder",
+      "methods": [{ "name": "<init>", "parameterTypes": [] }]
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.builder.GenAiModelOutputTokensSumMetricsBuilder",
+      "methods": [{ "name": "<init>", "parameterTypes": [] }]
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.builder.GenAiModelSlaMetricsBuilder",
+      "methods": [{ "name": "<init>", "parameterTypes": [] }]
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.builder.GenAiModelTotalEstimatedCostMetricsBuilder",
+      "methods": [{ "name": "<init>", "parameterTypes": [] }]
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.builder.GenAiModelTtftAvgMetricsBuilder",
+      "methods": [{ "name": "<init>", "parameterTypes": [] }]
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.builder.GenAiModelTtftPercentileMetricsBuilder",
+      "methods": [{ "name": "<init>", "parameterTypes": [] }]
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.builder.GenAiProviderAvgEstimatedCostMetricsBuilder",
+      "methods": [{ "name": "<init>", "parameterTypes": [] }]
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.builder.GenAiProviderCpmMetricsBuilder",
+      "methods": [{ "name": "<init>", "parameterTypes": [] }]
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.builder.GenAiProviderInputTokensAvgMetricsBuilder",
+      "methods": [{ "name": "<init>", "parameterTypes": [] }]
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.builder.GenAiProviderInputTokensSumMetricsBuilder",
+      "methods": [{ "name": "<init>", "parameterTypes": [] }]
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.builder.GenAiProviderLatencyPercentileMetricsBuilder",
+      "methods": [{ "name": "<init>", "parameterTypes": [] }]
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.builder.GenAiProviderOutputTokensAvgMetricsBuilder",
+      "methods": [{ "name": "<init>", "parameterTypes": [] }]
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.builder.GenAiProviderOutputTokensSumMetricsBuilder",
+      "methods": [{ "name": "<init>", "parameterTypes": [] }]
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.builder.GenAiProviderRespTimeMetricsBuilder",
+      "methods": [{ "name": "<init>", "parameterTypes": [] }]
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.builder.GenAiProviderSlaMetricsBuilder",
+      "methods": [{ "name": "<init>", "parameterTypes": [] }]
+    },
+    {
+      "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.builder.GenAiProviderTotalEstimatedCostMetricsBuilder",
+      "methods": [{ "name": "<init>", "parameterTypes": [] }]
+    },
+    {
       "type": "org.apache.skywalking.oap.server.core.source.oal.rt.metrics.builder.BrowserAppErrorRateMetricsBuilder",
       "methods": [
         {

--- a/oap-graalvm-server/pom.xml
+++ b/oap-graalvm-server/pom.xml
@@ -227,6 +227,10 @@
             <groupId>org.apache.skywalking</groupId>
             <artifactId>event-analyzer</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.skywalking</groupId>
+            <artifactId>gen-ai-analyzer</artifactId>
+        </dependency>
 
         <!-- Receivers -->
         <dependency>

--- a/oap-graalvm-server/src/main/assembly/distribution.xml
+++ b/oap-graalvm-server/src/main/assembly/distribution.xml
@@ -103,6 +103,8 @@
                 <include>service-apdex-threshold.yml</include>
                 <!-- Trace sampling policy (loaded by TraceSamplingPolicyWatcher) -->
                 <include>trace-sampling-policy-settings.yml</include>
+                <!-- GenAI pricing configuration (loaded by GenAIConfigLoader) -->
+                <include>gen-ai-config.yml</include>
             </includes>
         </fileSet>
         <!-- logs/ — empty directory for runtime logs -->

--- a/oap-graalvm-server/src/main/java/org/apache/skywalking/oap/server/graalvm/GraalVMOAPServerStartUp.java
+++ b/oap-graalvm-server/src/main/java/org/apache/skywalking/oap/server/graalvm/GraalVMOAPServerStartUp.java
@@ -55,6 +55,8 @@ import org.apache.skywalking.oap.log.analyzer.v2.module.LogAnalyzerModule;
 import org.apache.skywalking.oap.log.analyzer.v2.provider.LogAnalyzerModuleProvider;
 import org.apache.skywalking.oap.server.analyzer.event.EventAnalyzerModule;
 import org.apache.skywalking.oap.server.analyzer.event.EventAnalyzerModuleProvider;
+import org.apache.skywalking.oap.analyzer.genai.module.GenAIAnalyzerModule;
+import org.apache.skywalking.oap.analyzer.genai.GenAIAnalyzerModuleProvider;
 // Receivers
 import org.apache.skywalking.oap.server.receiver.sharing.server.SharingServerModule;
 import org.apache.skywalking.oap.server.receiver.sharing.server.SharingServerModuleProvider;
@@ -211,6 +213,7 @@ public class GraalVMOAPServerStartUp {
         manager.register(new AnalyzerModule(), new AnalyzerModuleProvider());
         manager.register(new LogAnalyzerModule(), new LogAnalyzerModuleProvider());
         manager.register(new EventAnalyzerModule(), new EventAnalyzerModuleProvider());
+        manager.register(new GenAIAnalyzerModule(), new GenAIAnalyzerModuleProvider());
 
         // Receivers
         manager.register(new SharingServerModule(), new SharingServerModuleProvider());

--- a/oap-graalvm-server/src/main/java/org/apache/skywalking/oap/server/library/util/YamlConfigLoaderUtils.java
+++ b/oap-graalvm-server/src/main/java/org/apache/skywalking/oap/server/library/util/YamlConfigLoaderUtils.java
@@ -26,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.yaml.snakeyaml.Yaml;
 
 import java.util.Set;
+import org.apache.skywalking.oap.analyzer.genai.config.GenAIConfig;
 import org.apache.skywalking.oap.log.analyzer.v2.provider.LogAnalyzerModuleConfig;
 import org.apache.skywalking.oap.query.debug.StatusQueryConfig;
 import org.apache.skywalking.oap.query.graphql.GraphQLQueryConfig;
@@ -117,32 +118,54 @@ public class YamlConfigLoaderUtils {
         if (dest == null) {
             return;
         }
-        if (dest instanceof ClusterModuleKubernetesConfig) {
+        if (dest instanceof CoreModuleConfig) {
+            copyToCoreModuleConfig((CoreModuleConfig) dest, src, moduleName, providerName);
+        } else if (dest instanceof ClusterModuleKubernetesConfig) {
             copyToClusterModuleKubernetesConfig((ClusterModuleKubernetesConfig) dest, src, moduleName, providerName);
         } else if (dest instanceof SharingServerConfig) {
             copyToSharingServerConfig((SharingServerConfig) dest, src, moduleName, providerName);
+        } else if (dest instanceof AnalyzerModuleConfig) {
+            copyToAnalyzerModuleConfig((AnalyzerModuleConfig) dest, src, moduleName, providerName);
         } else if (dest instanceof ZipkinReceiverConfig) {
             copyToZipkinReceiverConfig((ZipkinReceiverConfig) dest, src, moduleName, providerName);
+        } else if (dest instanceof GenAIConfig) {
+            copyToGenAIConfig((GenAIConfig) dest, src, moduleName, providerName);
         } else if (dest instanceof ZipkinQueryConfig) {
             copyToZipkinQueryConfig((ZipkinQueryConfig) dest, src, moduleName, providerName);
+        } else if (dest instanceof StatusQueryConfig) {
+            copyToStatusQueryConfig((StatusQueryConfig) dest, src, moduleName, providerName);
+        } else if (dest instanceof EnvoyMetricReceiverConfig) {
+            copyToEnvoyMetricReceiverConfig((EnvoyMetricReceiverConfig) dest, src, moduleName, providerName);
+        } else if (dest instanceof LogAnalyzerModuleConfig) {
+            copyToLogAnalyzerModuleConfig((LogAnalyzerModuleConfig) dest, src, moduleName, providerName);
+        } else if (dest instanceof OtelMetricReceiverConfig) {
+            copyToOtelMetricReceiverConfig((OtelMetricReceiverConfig) dest, src, moduleName, providerName);
         } else if (dest instanceof BrowserServiceModuleConfig) {
             copyToBrowserServiceModuleConfig((BrowserServiceModuleConfig) dest, src, moduleName, providerName);
         } else if (dest instanceof ConfigurationDiscoveryModuleConfig) {
             copyToConfigurationDiscoveryModuleConfig((ConfigurationDiscoveryModuleConfig) dest, src, moduleName, providerName);
         } else if (dest instanceof ZabbixModuleConfig) {
             copyToZabbixModuleConfig((ZabbixModuleConfig) dest, src, moduleName, providerName);
+        } else if (dest instanceof EBPFReceiverModuleConfig) {
+            copyToEBPFReceiverModuleConfig((EBPFReceiverModuleConfig) dest, src, moduleName, providerName);
         } else if (dest instanceof AsyncProfilerModuleConfig) {
             copyToAsyncProfilerModuleConfig((AsyncProfilerModuleConfig) dest, src, moduleName, providerName);
         } else if (dest instanceof PprofModuleConfig) {
             copyToPprofModuleConfig((PprofModuleConfig) dest, src, moduleName, providerName);
         } else if (dest instanceof TelegrafModuleConfig) {
             copyToTelegrafModuleConfig((TelegrafModuleConfig) dest, src, moduleName, providerName);
+        } else if (dest instanceof AWSFirehoseReceiverModuleConfig) {
+            copyToAWSFirehoseReceiverModuleConfig((AWSFirehoseReceiverModuleConfig) dest, src, moduleName, providerName);
         } else if (dest instanceof KafkaFetcherConfig) {
             copyToKafkaFetcherConfig((KafkaFetcherConfig) dest, src, moduleName, providerName);
+        } else if (dest instanceof CiliumFetcherConfig) {
+            copyToCiliumFetcherConfig((CiliumFetcherConfig) dest, src, moduleName, providerName);
         } else if (dest instanceof BanyanDBStorageConfig) {
             copyToBanyanDBStorageConfig((BanyanDBStorageConfig) dest, src, moduleName, providerName);
         } else if (dest instanceof GraphQLQueryConfig) {
             copyToGraphQLQueryConfig((GraphQLQueryConfig) dest, src, moduleName, providerName);
+        } else if (dest instanceof HealthCheckerConfig) {
+            copyToHealthCheckerConfig((HealthCheckerConfig) dest, src, moduleName, providerName);
         } else if (dest instanceof AIPipelineConfig) {
             copyToAIPipelineConfig((AIPipelineConfig) dest, src, moduleName, providerName);
         } else if (dest instanceof PromQLConfig) {
@@ -157,26 +180,10 @@ public class YamlConfigLoaderUtils {
             copyToExporterSetting((ExporterSetting) dest, src, moduleName, providerName);
         } else if (dest instanceof ConfigmapConfigurationSettings) {
             copyToConfigmapConfigurationSettings((ConfigmapConfigurationSettings) dest, src, moduleName, providerName);
-        } else if (dest instanceof CoreModuleConfig) {
-            copyToCoreModuleConfig((CoreModuleConfig) dest, src, moduleName, providerName);
-        } else if (dest instanceof AnalyzerModuleConfig) {
-            copyToAnalyzerModuleConfig((AnalyzerModuleConfig) dest, src, moduleName, providerName);
-        } else if (dest instanceof LogAnalyzerModuleConfig) {
-            copyToLogAnalyzerModuleConfig((LogAnalyzerModuleConfig) dest, src, moduleName, providerName);
-        } else if (dest instanceof EnvoyMetricReceiverConfig) {
-            copyToEnvoyMetricReceiverConfig((EnvoyMetricReceiverConfig) dest, src, moduleName, providerName);
-        } else if (dest instanceof OtelMetricReceiverConfig) {
-            copyToOtelMetricReceiverConfig((OtelMetricReceiverConfig) dest, src, moduleName, providerName);
-        } else if (dest instanceof EBPFReceiverModuleConfig) {
-            copyToEBPFReceiverModuleConfig((EBPFReceiverModuleConfig) dest, src, moduleName, providerName);
-        } else if (dest instanceof AWSFirehoseReceiverModuleConfig) {
-            copyToAWSFirehoseReceiverModuleConfig((AWSFirehoseReceiverModuleConfig) dest, src, moduleName, providerName);
-        } else if (dest instanceof CiliumFetcherConfig) {
-            copyToCiliumFetcherConfig((CiliumFetcherConfig) dest, src, moduleName, providerName);
-        } else if (dest instanceof StatusQueryConfig) {
-            copyToStatusQueryConfig((StatusQueryConfig) dest, src, moduleName, providerName);
-        } else if (dest instanceof HealthCheckerConfig) {
-            copyToHealthCheckerConfig((HealthCheckerConfig) dest, src, moduleName, providerName);
+        } else if (dest instanceof GenAIConfig.Model) {
+            copyToModel((GenAIConfig.Model) dest, src, moduleName, providerName);
+        } else if (dest instanceof GenAIConfig.Provider) {
+            copyToProvider((GenAIConfig.Provider) dest, src, moduleName, providerName);
         } else if (dest instanceof BanyanDBStorageConfig.Global) {
             copyToGlobal((BanyanDBStorageConfig.Global) dest, src, moduleName, providerName);
         } else if (dest instanceof BanyanDBStorageConfig.RecordsNormal) {
@@ -214,795 +221,6 @@ public class YamlConfigLoaderUtils {
                 + dest.getClass().getName()
                 + " in " + providerName + " provider of " + moduleName + " module."
                 + " Add it to ConfigInitializerGenerator and regenerate.");
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private static void copyToClusterModuleKubernetesConfig(
-            final ClusterModuleKubernetesConfig cfg, final Properties src,
-            final String moduleName, final String providerName) {
-        final Enumeration<?> propertyNames = src.propertyNames();
-        while (propertyNames.hasMoreElements()) {
-            final String key = (String) propertyNames.nextElement();
-            final Object value = src.get(key);
-            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
-            switch (key) {
-                case "namespace":
-                    cfg.setNamespace((String) value);
-                    break;
-                case "labelSelector":
-                    cfg.setLabelSelector((String) value);
-                    break;
-                case "uidEnvName":
-                    cfg.setUidEnvName((String) value);
-                    break;
-                default:
-                    log.warn("{} setting is not supported in {} provider of {} module",
-                        key, providerName, moduleName);
-                    break;
-            }
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private static void copyToSharingServerConfig(
-            final SharingServerConfig cfg, final Properties src,
-            final String moduleName, final String providerName) {
-        final Enumeration<?> propertyNames = src.propertyNames();
-        while (propertyNames.hasMoreElements()) {
-            final String key = (String) propertyNames.nextElement();
-            final Object value = src.get(key);
-            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
-            switch (key) {
-                case "restHost":
-                    cfg.setRestHost((String) value);
-                    break;
-                case "restPort":
-                    cfg.setRestPort(((Number) value).intValue());
-                    break;
-                case "restContextPath":
-                    cfg.setRestContextPath((String) value);
-                    break;
-                case "restIdleTimeOut":
-                    cfg.setRestIdleTimeOut(((Number) value).longValue());
-                    break;
-                case "restAcceptQueueSize":
-                    cfg.setRestAcceptQueueSize(((Number) value).intValue());
-                    break;
-                case "gRPCHost":
-                    cfg.setGRPCHost((String) value);
-                    break;
-                case "gRPCPort":
-                    cfg.setGRPCPort(((Number) value).intValue());
-                    break;
-                case "maxConcurrentCallsPerConnection":
-                    cfg.setMaxConcurrentCallsPerConnection(((Number) value).intValue());
-                    break;
-                case "maxMessageSize":
-                    cfg.setMaxMessageSize(((Number) value).intValue());
-                    break;
-                case "gRPCThreadPoolSize":
-                    cfg.setGRPCThreadPoolSize(((Number) value).intValue());
-                    break;
-                case "authentication":
-                    cfg.setAuthentication((String) value);
-                    break;
-                case "gRPCSslEnabled":
-                    cfg.setGRPCSslEnabled((boolean) value);
-                    break;
-                case "gRPCSslKeyPath":
-                    cfg.setGRPCSslKeyPath((String) value);
-                    break;
-                case "gRPCSslCertChainPath":
-                    cfg.setGRPCSslCertChainPath((String) value);
-                    break;
-                case "gRPCSslTrustedCAsPath":
-                    cfg.setGRPCSslTrustedCAsPath((String) value);
-                    break;
-                case "httpMaxRequestHeaderSize":
-                    cfg.setHttpMaxRequestHeaderSize(((Number) value).intValue());
-                    break;
-                default:
-                    log.warn("{} setting is not supported in {} provider of {} module",
-                        key, providerName, moduleName);
-                    break;
-            }
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private static void copyToZipkinReceiverConfig(
-            final ZipkinReceiverConfig cfg, final Properties src,
-            final String moduleName, final String providerName) {
-        final Enumeration<?> propertyNames = src.propertyNames();
-        while (propertyNames.hasMoreElements()) {
-            final String key = (String) propertyNames.nextElement();
-            final Object value = src.get(key);
-            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
-            switch (key) {
-                case "enableHttpCollector":
-                    cfg.setEnableHttpCollector((boolean) value);
-                    break;
-                case "restHost":
-                    cfg.setRestHost((String) value);
-                    break;
-                case "restPort":
-                    cfg.setRestPort(((Number) value).intValue());
-                    break;
-                case "restContextPath":
-                    cfg.setRestContextPath((String) value);
-                    break;
-                case "restIdleTimeOut":
-                    cfg.setRestIdleTimeOut(((Number) value).longValue());
-                    break;
-                case "restAcceptQueueSize":
-                    cfg.setRestAcceptQueueSize(((Number) value).intValue());
-                    break;
-                case "searchableTracesTags":
-                    cfg.setSearchableTracesTags((String) value);
-                    break;
-                case "sampleRate":
-                    cfg.setSampleRate(((Number) value).intValue());
-                    break;
-                case "maxSpansPerSecond":
-                    cfg.setMaxSpansPerSecond(((Number) value).intValue());
-                    break;
-                case "enableKafkaCollector":
-                    cfg.setEnableKafkaCollector((boolean) value);
-                    break;
-                case "kafkaBootstrapServers":
-                    cfg.setKafkaBootstrapServers((String) value);
-                    break;
-                case "kafkaGroupId":
-                    cfg.setKafkaGroupId((String) value);
-                    break;
-                case "kafkaTopic":
-                    cfg.setKafkaTopic((String) value);
-                    break;
-                case "kafkaConsumerConfig":
-                    cfg.setKafkaConsumerConfig((String) value);
-                    break;
-                case "kafkaConsumers":
-                    cfg.setKafkaConsumers(((Number) value).intValue());
-                    break;
-                case "kafkaHandlerThreadPoolSize":
-                    cfg.setKafkaHandlerThreadPoolSize(((Number) value).intValue());
-                    break;
-                case "kafkaHandlerThreadPoolQueueSize":
-                    cfg.setKafkaHandlerThreadPoolQueueSize(((Number) value).intValue());
-                    break;
-                default:
-                    log.warn("{} setting is not supported in {} provider of {} module",
-                        key, providerName, moduleName);
-                    break;
-            }
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private static void copyToZipkinQueryConfig(
-            final ZipkinQueryConfig cfg, final Properties src,
-            final String moduleName, final String providerName) {
-        final Enumeration<?> propertyNames = src.propertyNames();
-        while (propertyNames.hasMoreElements()) {
-            final String key = (String) propertyNames.nextElement();
-            final Object value = src.get(key);
-            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
-            switch (key) {
-                case "restHost":
-                    cfg.setRestHost((String) value);
-                    break;
-                case "restPort":
-                    cfg.setRestPort(((Number) value).intValue());
-                    break;
-                case "restContextPath":
-                    cfg.setRestContextPath((String) value);
-                    break;
-                case "restIdleTimeOut":
-                    cfg.setRestIdleTimeOut(((Number) value).longValue());
-                    break;
-                case "restAcceptQueueSize":
-                    cfg.setRestAcceptQueueSize(((Number) value).intValue());
-                    break;
-                case "lookback":
-                    cfg.setLookback(((Number) value).longValue());
-                    break;
-                case "namesMaxAge":
-                    cfg.setNamesMaxAge(((Number) value).intValue());
-                    break;
-                case "uiQueryLimit":
-                    cfg.setUiQueryLimit(((Number) value).intValue());
-                    break;
-                case "uiEnvironment":
-                    cfg.setUiEnvironment((String) value);
-                    break;
-                case "uiDefaultLookback":
-                    cfg.setUiDefaultLookback(((Number) value).longValue());
-                    break;
-                case "uiSearchEnabled":
-                    cfg.setUiSearchEnabled((boolean) value);
-                    break;
-                default:
-                    log.warn("{} setting is not supported in {} provider of {} module",
-                        key, providerName, moduleName);
-                    break;
-            }
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private static void copyToBrowserServiceModuleConfig(
-            final BrowserServiceModuleConfig cfg, final Properties src,
-            final String moduleName, final String providerName) {
-        final Enumeration<?> propertyNames = src.propertyNames();
-        while (propertyNames.hasMoreElements()) {
-            final String key = (String) propertyNames.nextElement();
-            final Object value = src.get(key);
-            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
-            switch (key) {
-                case "sampleRate":
-                    cfg.setSampleRate(((Number) value).intValue());
-                    break;
-                default:
-                    log.warn("{} setting is not supported in {} provider of {} module",
-                        key, providerName, moduleName);
-                    break;
-            }
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private static void copyToConfigurationDiscoveryModuleConfig(
-            final ConfigurationDiscoveryModuleConfig cfg, final Properties src,
-            final String moduleName, final String providerName) {
-        final Enumeration<?> propertyNames = src.propertyNames();
-        while (propertyNames.hasMoreElements()) {
-            final String key = (String) propertyNames.nextElement();
-            final Object value = src.get(key);
-            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
-            switch (key) {
-                case "disableMessageDigest":
-                    cfg.setDisableMessageDigest((boolean) value);
-                    break;
-                default:
-                    log.warn("{} setting is not supported in {} provider of {} module",
-                        key, providerName, moduleName);
-                    break;
-            }
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private static void copyToZabbixModuleConfig(
-            final ZabbixModuleConfig cfg, final Properties src,
-            final String moduleName, final String providerName) {
-        final Enumeration<?> propertyNames = src.propertyNames();
-        while (propertyNames.hasMoreElements()) {
-            final String key = (String) propertyNames.nextElement();
-            final Object value = src.get(key);
-            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
-            switch (key) {
-                case "port":
-                    cfg.setPort(((Number) value).intValue());
-                    break;
-                case "host":
-                    cfg.setHost((String) value);
-                    break;
-                case "activeFiles":
-                    cfg.setActiveFiles((String) value);
-                    break;
-                default:
-                    log.warn("{} setting is not supported in {} provider of {} module",
-                        key, providerName, moduleName);
-                    break;
-            }
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private static void copyToAsyncProfilerModuleConfig(
-            final AsyncProfilerModuleConfig cfg, final Properties src,
-            final String moduleName, final String providerName) {
-        final Enumeration<?> propertyNames = src.propertyNames();
-        while (propertyNames.hasMoreElements()) {
-            final String key = (String) propertyNames.nextElement();
-            final Object value = src.get(key);
-            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
-            switch (key) {
-                case "jfrMaxSize":
-                    cfg.setJfrMaxSize(((Number) value).intValue());
-                    break;
-                case "memoryParserEnabled":
-                    cfg.setMemoryParserEnabled((boolean) value);
-                    break;
-                default:
-                    log.warn("{} setting is not supported in {} provider of {} module",
-                        key, providerName, moduleName);
-                    break;
-            }
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private static void copyToPprofModuleConfig(
-            final PprofModuleConfig cfg, final Properties src,
-            final String moduleName, final String providerName) {
-        final Enumeration<?> propertyNames = src.propertyNames();
-        while (propertyNames.hasMoreElements()) {
-            final String key = (String) propertyNames.nextElement();
-            final Object value = src.get(key);
-            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
-            switch (key) {
-                case "pprofMaxSize":
-                    cfg.setPprofMaxSize(((Number) value).intValue());
-                    break;
-                case "memoryParserEnabled":
-                    cfg.setMemoryParserEnabled((boolean) value);
-                    break;
-                default:
-                    log.warn("{} setting is not supported in {} provider of {} module",
-                        key, providerName, moduleName);
-                    break;
-            }
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private static void copyToTelegrafModuleConfig(
-            final TelegrafModuleConfig cfg, final Properties src,
-            final String moduleName, final String providerName) {
-        final Enumeration<?> propertyNames = src.propertyNames();
-        while (propertyNames.hasMoreElements()) {
-            final String key = (String) propertyNames.nextElement();
-            final Object value = src.get(key);
-            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
-            switch (key) {
-                case "activeFiles":
-                    cfg.setActiveFiles((String) value);
-                    break;
-                default:
-                    log.warn("{} setting is not supported in {} provider of {} module",
-                        key, providerName, moduleName);
-                    break;
-            }
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private static void copyToKafkaFetcherConfig(
-            final KafkaFetcherConfig cfg, final Properties src,
-            final String moduleName, final String providerName) {
-        final Enumeration<?> propertyNames = src.propertyNames();
-        while (propertyNames.hasMoreElements()) {
-            final String key = (String) propertyNames.nextElement();
-            final Object value = src.get(key);
-            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
-            switch (key) {
-                case "kafkaConsumerConfig":
-                    cfg.setKafkaConsumerConfig((Properties) value);
-                    break;
-                case "bootstrapServers":
-                    cfg.setBootstrapServers((String) value);
-                    break;
-                case "groupId":
-                    cfg.setGroupId((String) value);
-                    break;
-                case "partitions":
-                    cfg.setPartitions(((Number) value).intValue());
-                    break;
-                case "replicationFactor":
-                    cfg.setReplicationFactor(((Number) value).intValue());
-                    break;
-                case "enableNativeProtoLog":
-                    cfg.setEnableNativeProtoLog((boolean) value);
-                    break;
-                case "enableNativeJsonLog":
-                    cfg.setEnableNativeJsonLog((boolean) value);
-                    break;
-                case "configPath":
-                    cfg.setConfigPath((String) value);
-                    break;
-                case "topicNameOfMetrics":
-                    cfg.setTopicNameOfMetrics((String) value);
-                    break;
-                case "topicNameOfProfiling":
-                    cfg.setTopicNameOfProfiling((String) value);
-                    break;
-                case "topicNameOfTracingSegments":
-                    cfg.setTopicNameOfTracingSegments((String) value);
-                    break;
-                case "topicNameOfManagements":
-                    cfg.setTopicNameOfManagements((String) value);
-                    break;
-                case "topicNameOfMeters":
-                    cfg.setTopicNameOfMeters((String) value);
-                    break;
-                case "topicNameOfLogs":
-                    cfg.setTopicNameOfLogs((String) value);
-                    break;
-                case "topicNameOfJsonLogs":
-                    cfg.setTopicNameOfJsonLogs((String) value);
-                    break;
-                case "kafkaHandlerThreadPoolSize":
-                    cfg.setKafkaHandlerThreadPoolSize(((Number) value).intValue());
-                    break;
-                case "kafkaHandlerThreadPoolQueueSize":
-                    cfg.setKafkaHandlerThreadPoolQueueSize(((Number) value).intValue());
-                    break;
-                case "namespace":
-                    cfg.setNamespace((String) value);
-                    break;
-                case "mm2SourceAlias":
-                    cfg.setMm2SourceAlias((String) value);
-                    break;
-                case "mm2SourceSeparator":
-                    cfg.setMm2SourceSeparator((String) value);
-                    break;
-                case "consumers":
-                    cfg.setConsumers(((Number) value).intValue());
-                    break;
-                default:
-                    log.warn("{} setting is not supported in {} provider of {} module",
-                        key, providerName, moduleName);
-                    break;
-            }
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private static void copyToBanyanDBStorageConfig(
-            final BanyanDBStorageConfig cfg, final Properties src,
-            final String moduleName, final String providerName) {
-        final Enumeration<?> propertyNames = src.propertyNames();
-        while (propertyNames.hasMoreElements()) {
-            final String key = (String) propertyNames.nextElement();
-            final Object value = src.get(key);
-            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
-            switch (key) {
-                case "global":
-                    cfg.setGlobal((BanyanDBStorageConfig.Global) value);
-                    break;
-                case "recordsNormal":
-                    cfg.setRecordsNormal((BanyanDBStorageConfig.RecordsNormal) value);
-                    break;
-                case "trace":
-                    cfg.setTrace((BanyanDBStorageConfig.Trace) value);
-                    break;
-                case "zipkinTrace":
-                    cfg.setZipkinTrace((BanyanDBStorageConfig.ZipkinTrace) value);
-                    break;
-                case "recordsTrace":
-                    cfg.setRecordsTrace((BanyanDBStorageConfig.RecordsTrace) value);
-                    break;
-                case "recordsZipkinTrace":
-                    cfg.setRecordsZipkinTrace((BanyanDBStorageConfig.RecordsZipkinTrace) value);
-                    break;
-                case "recordsLog":
-                    cfg.setRecordsLog((BanyanDBStorageConfig.RecordsLog) value);
-                    break;
-                case "recordsBrowserErrorLog":
-                    cfg.setRecordsBrowserErrorLog((BanyanDBStorageConfig.RecordsBrowserErrorLog) value);
-                    break;
-                case "metricsMin":
-                    cfg.setMetricsMin((BanyanDBStorageConfig.MetricsMin) value);
-                    break;
-                case "metricsHour":
-                    cfg.setMetricsHour((BanyanDBStorageConfig.MetricsHour) value);
-                    break;
-                case "metricsDay":
-                    cfg.setMetricsDay((BanyanDBStorageConfig.MetricsDay) value);
-                    break;
-                case "metadata":
-                    cfg.setMetadata((BanyanDBStorageConfig.Metadata) value);
-                    break;
-                case "property":
-                    cfg.setProperty((BanyanDBStorageConfig.Property) value);
-                    break;
-                case "topNConfigs":
-                    cfg.setTopNConfigs((Map) value);
-                    break;
-                default:
-                    log.warn("{} setting is not supported in {} provider of {} module",
-                        key, providerName, moduleName);
-                    break;
-            }
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private static void copyToGraphQLQueryConfig(
-            final GraphQLQueryConfig cfg, final Properties src,
-            final String moduleName, final String providerName) {
-        final Enumeration<?> propertyNames = src.propertyNames();
-        while (propertyNames.hasMoreElements()) {
-            final String key = (String) propertyNames.nextElement();
-            final Object value = src.get(key);
-            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
-            switch (key) {
-                case "enableLogTestTool":
-                    cfg.setEnableLogTestTool((boolean) value);
-                    break;
-                case "maxQueryComplexity":
-                    cfg.setMaxQueryComplexity(((Number) value).intValue());
-                    break;
-                case "enableUpdateUITemplate":
-                    cfg.setEnableUpdateUITemplate((boolean) value);
-                    break;
-                case "enableOnDemandPodLog":
-                    cfg.setEnableOnDemandPodLog((boolean) value);
-                    break;
-                default:
-                    log.warn("{} setting is not supported in {} provider of {} module",
-                        key, providerName, moduleName);
-                    break;
-            }
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private static void copyToAIPipelineConfig(
-            final AIPipelineConfig cfg, final Properties src,
-            final String moduleName, final String providerName) {
-        final Enumeration<?> propertyNames = src.propertyNames();
-        while (propertyNames.hasMoreElements()) {
-            final String key = (String) propertyNames.nextElement();
-            final Object value = src.get(key);
-            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
-            switch (key) {
-                case "uriRecognitionServerAddr":
-                    cfg.setUriRecognitionServerAddr((String) value);
-                    break;
-                case "uriRecognitionServerPort":
-                    cfg.setUriRecognitionServerPort(((Number) value).intValue());
-                    break;
-                case "baselineServerAddr":
-                    cfg.setBaselineServerAddr((String) value);
-                    break;
-                case "baselineServerPort":
-                    cfg.setBaselineServerPort(((Number) value).intValue());
-                    break;
-                default:
-                    log.warn("{} setting is not supported in {} provider of {} module",
-                        key, providerName, moduleName);
-                    break;
-            }
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private static void copyToPromQLConfig(
-            final PromQLConfig cfg, final Properties src,
-            final String moduleName, final String providerName) {
-        final Enumeration<?> propertyNames = src.propertyNames();
-        while (propertyNames.hasMoreElements()) {
-            final String key = (String) propertyNames.nextElement();
-            final Object value = src.get(key);
-            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
-            switch (key) {
-                case "restHost":
-                    cfg.setRestHost((String) value);
-                    break;
-                case "restPort":
-                    cfg.setRestPort(((Number) value).intValue());
-                    break;
-                case "restContextPath":
-                    cfg.setRestContextPath((String) value);
-                    break;
-                case "restIdleTimeOut":
-                    cfg.setRestIdleTimeOut(((Number) value).longValue());
-                    break;
-                case "restAcceptQueueSize":
-                    cfg.setRestAcceptQueueSize(((Number) value).intValue());
-                    break;
-                case "buildInfoVersion":
-                    cfg.setBuildInfoVersion((String) value);
-                    break;
-                case "buildInfoRevision":
-                    cfg.setBuildInfoRevision((String) value);
-                    break;
-                case "buildInfoBranch":
-                    cfg.setBuildInfoBranch((String) value);
-                    break;
-                case "buildInfoBuildUser":
-                    cfg.setBuildInfoBuildUser((String) value);
-                    break;
-                case "buildInfoBuildDate":
-                    cfg.setBuildInfoBuildDate((String) value);
-                    break;
-                case "buildInfoGoVersion":
-                    cfg.setBuildInfoGoVersion((String) value);
-                    break;
-                default:
-                    log.warn("{} setting is not supported in {} provider of {} module",
-                        key, providerName, moduleName);
-                    break;
-            }
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private static void copyToLogQLConfig(
-            final LogQLConfig cfg, final Properties src,
-            final String moduleName, final String providerName) {
-        final Enumeration<?> propertyNames = src.propertyNames();
-        while (propertyNames.hasMoreElements()) {
-            final String key = (String) propertyNames.nextElement();
-            final Object value = src.get(key);
-            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
-            switch (key) {
-                case "restHost":
-                    cfg.setRestHost((String) value);
-                    break;
-                case "restPort":
-                    cfg.setRestPort(((Number) value).intValue());
-                    break;
-                case "restContextPath":
-                    cfg.setRestContextPath((String) value);
-                    break;
-                case "restIdleTimeOut":
-                    cfg.setRestIdleTimeOut(((Number) value).longValue());
-                    break;
-                case "restAcceptQueueSize":
-                    cfg.setRestAcceptQueueSize(((Number) value).intValue());
-                    break;
-                default:
-                    log.warn("{} setting is not supported in {} provider of {} module",
-                        key, providerName, moduleName);
-                    break;
-            }
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private static void copyToTraceQLConfig(
-            final TraceQLConfig cfg, final Properties src,
-            final String moduleName, final String providerName) {
-        final Enumeration<?> propertyNames = src.propertyNames();
-        while (propertyNames.hasMoreElements()) {
-            final String key = (String) propertyNames.nextElement();
-            final Object value = src.get(key);
-            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
-            switch (key) {
-                case "restHost":
-                    cfg.setRestHost((String) value);
-                    break;
-                case "restPort":
-                    cfg.setRestPort(((Number) value).intValue());
-                    break;
-                case "enableDatasourceZipkin":
-                    cfg.setEnableDatasourceZipkin((boolean) value);
-                    break;
-                case "enableDatasourceSkywalking":
-                    cfg.setEnableDatasourceSkywalking((boolean) value);
-                    break;
-                case "restContextPathZipkin":
-                    cfg.setRestContextPathZipkin((String) value);
-                    break;
-                case "restContextPathSkywalking":
-                    cfg.setRestContextPathSkywalking((String) value);
-                    break;
-                case "restIdleTimeOut":
-                    cfg.setRestIdleTimeOut(((Number) value).longValue());
-                    break;
-                case "restAcceptQueueSize":
-                    cfg.setRestAcceptQueueSize(((Number) value).intValue());
-                    break;
-                default:
-                    log.warn("{} setting is not supported in {} provider of {} module",
-                        key, providerName, moduleName);
-                    break;
-            }
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private static void copyToPrometheusConfig(
-            final PrometheusConfig cfg, final Properties src,
-            final String moduleName, final String providerName) {
-        final Enumeration<?> propertyNames = src.propertyNames();
-        while (propertyNames.hasMoreElements()) {
-            final String key = (String) propertyNames.nextElement();
-            final Object value = src.get(key);
-            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
-            switch (key) {
-                case "host":
-                    cfg.setHost((String) value);
-                    break;
-                case "port":
-                    cfg.setPort(((Number) value).intValue());
-                    break;
-                case "sslEnabled":
-                    cfg.setSslEnabled((boolean) value);
-                    break;
-                case "sslKeyPath":
-                    cfg.setSslKeyPath((String) value);
-                    break;
-                case "sslCertChainPath":
-                    cfg.setSslCertChainPath((String) value);
-                    break;
-                default:
-                    log.warn("{} setting is not supported in {} provider of {} module",
-                        key, providerName, moduleName);
-                    break;
-            }
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private static void copyToExporterSetting(
-            final ExporterSetting cfg, final Properties src,
-            final String moduleName, final String providerName) {
-        final Enumeration<?> propertyNames = src.propertyNames();
-        while (propertyNames.hasMoreElements()) {
-            final String key = (String) propertyNames.nextElement();
-            final Object value = src.get(key);
-            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
-            switch (key) {
-                case "enableGRPCMetrics":
-                    cfg.setEnableGRPCMetrics((boolean) value);
-                    break;
-                case "gRPCTargetHost":
-                    cfg.setGRPCTargetHost((String) value);
-                    break;
-                case "gRPCTargetPort":
-                    cfg.setGRPCTargetPort(((Number) value).intValue());
-                    break;
-                case "bufferSize":
-                    cfg.setBufferSize(((Number) value).intValue());
-                    break;
-                case "enableKafkaTrace":
-                    cfg.setEnableKafkaTrace((boolean) value);
-                    break;
-                case "enableKafkaLog":
-                    cfg.setEnableKafkaLog((boolean) value);
-                    break;
-                case "kafkaBootstrapServers":
-                    cfg.setKafkaBootstrapServers((String) value);
-                    break;
-                case "kafkaProducerConfig":
-                    cfg.setKafkaProducerConfig((String) value);
-                    break;
-                case "kafkaTopicTrace":
-                    cfg.setKafkaTopicTrace((String) value);
-                    break;
-                case "kafkaTopicLog":
-                    cfg.setKafkaTopicLog((String) value);
-                    break;
-                case "exportErrorStatusTraceOnly":
-                    cfg.setExportErrorStatusTraceOnly((boolean) value);
-                    break;
-                default:
-                    log.warn("{} setting is not supported in {} provider of {} module",
-                        key, providerName, moduleName);
-                    break;
-            }
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private static void copyToConfigmapConfigurationSettings(
-            final ConfigmapConfigurationSettings cfg, final Properties src,
-            final String moduleName, final String providerName) {
-        final Enumeration<?> propertyNames = src.propertyNames();
-        while (propertyNames.hasMoreElements()) {
-            final String key = (String) propertyNames.nextElement();
-            final Object value = src.get(key);
-            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
-            switch (key) {
-                case "namespace":
-                    cfg.setNamespace((String) value);
-                    break;
-                case "labelSelector":
-                    cfg.setLabelSelector((String) value);
-                    break;
-                case "period":
-                    cfg.setPeriod((Integer) value);
-                    break;
-                default:
-                    log.warn("{} setting is not supported in {} provider of {} module",
-                        key, providerName, moduleName);
-                    break;
-            }
         }
     }
 
@@ -1191,6 +409,99 @@ public class YamlConfigLoaderUtils {
     }
 
     @SuppressWarnings("unchecked")
+    private static void copyToClusterModuleKubernetesConfig(
+            final ClusterModuleKubernetesConfig cfg, final Properties src,
+            final String moduleName, final String providerName) {
+        final Enumeration<?> propertyNames = src.propertyNames();
+        while (propertyNames.hasMoreElements()) {
+            final String key = (String) propertyNames.nextElement();
+            final Object value = src.get(key);
+            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
+            switch (key) {
+                case "namespace":
+                    cfg.setNamespace((String) value);
+                    break;
+                case "labelSelector":
+                    cfg.setLabelSelector((String) value);
+                    break;
+                case "uidEnvName":
+                    cfg.setUidEnvName((String) value);
+                    break;
+                default:
+                    log.warn("{} setting is not supported in {} provider of {} module",
+                        key, providerName, moduleName);
+                    break;
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void copyToSharingServerConfig(
+            final SharingServerConfig cfg, final Properties src,
+            final String moduleName, final String providerName) {
+        final Enumeration<?> propertyNames = src.propertyNames();
+        while (propertyNames.hasMoreElements()) {
+            final String key = (String) propertyNames.nextElement();
+            final Object value = src.get(key);
+            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
+            switch (key) {
+                case "restHost":
+                    cfg.setRestHost((String) value);
+                    break;
+                case "restPort":
+                    cfg.setRestPort(((Number) value).intValue());
+                    break;
+                case "restContextPath":
+                    cfg.setRestContextPath((String) value);
+                    break;
+                case "restIdleTimeOut":
+                    cfg.setRestIdleTimeOut(((Number) value).longValue());
+                    break;
+                case "restAcceptQueueSize":
+                    cfg.setRestAcceptQueueSize(((Number) value).intValue());
+                    break;
+                case "gRPCHost":
+                    cfg.setGRPCHost((String) value);
+                    break;
+                case "gRPCPort":
+                    cfg.setGRPCPort(((Number) value).intValue());
+                    break;
+                case "maxConcurrentCallsPerConnection":
+                    cfg.setMaxConcurrentCallsPerConnection(((Number) value).intValue());
+                    break;
+                case "maxMessageSize":
+                    cfg.setMaxMessageSize(((Number) value).intValue());
+                    break;
+                case "gRPCThreadPoolSize":
+                    cfg.setGRPCThreadPoolSize(((Number) value).intValue());
+                    break;
+                case "authentication":
+                    cfg.setAuthentication((String) value);
+                    break;
+                case "gRPCSslEnabled":
+                    cfg.setGRPCSslEnabled((boolean) value);
+                    break;
+                case "gRPCSslKeyPath":
+                    cfg.setGRPCSslKeyPath((String) value);
+                    break;
+                case "gRPCSslCertChainPath":
+                    cfg.setGRPCSslCertChainPath((String) value);
+                    break;
+                case "gRPCSslTrustedCAsPath":
+                    cfg.setGRPCSslTrustedCAsPath((String) value);
+                    break;
+                case "httpMaxRequestHeaderSize":
+                    cfg.setHttpMaxRequestHeaderSize(((Number) value).intValue());
+                    break;
+                default:
+                    log.warn("{} setting is not supported in {} provider of {} module",
+                        key, providerName, moduleName);
+                    break;
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
     private static void copyToAnalyzerModuleConfig(
             final AnalyzerModuleConfig cfg, final Properties src,
             final String moduleName, final String providerName) {
@@ -1260,8 +571,8 @@ public class YamlConfigLoaderUtils {
     }
 
     @SuppressWarnings("unchecked")
-    private static void copyToLogAnalyzerModuleConfig(
-            final LogAnalyzerModuleConfig cfg, final Properties src,
+    private static void copyToZipkinReceiverConfig(
+            final ZipkinReceiverConfig cfg, final Properties src,
             final String moduleName, final String providerName) {
         final Enumeration<?> propertyNames = src.propertyNames();
         while (propertyNames.hasMoreElements()) {
@@ -1269,17 +580,149 @@ public class YamlConfigLoaderUtils {
             final Object value = src.get(key);
             log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
             switch (key) {
-                case "lalPath":
-                    cfg.setLalPath((String) value);
+                case "enableHttpCollector":
+                    cfg.setEnableHttpCollector((boolean) value);
                     break;
-                case "malPath":
-                    cfg.setMalPath((String) value);
+                case "restHost":
+                    cfg.setRestHost((String) value);
                     break;
-                case "lalFiles":
-                    cfg.setLalFiles((String) value);
+                case "restPort":
+                    cfg.setRestPort(((Number) value).intValue());
                     break;
-                case "malFiles":
-                    cfg.setMalFiles((String) value);
+                case "restContextPath":
+                    cfg.setRestContextPath((String) value);
+                    break;
+                case "restIdleTimeOut":
+                    cfg.setRestIdleTimeOut(((Number) value).longValue());
+                    break;
+                case "restAcceptQueueSize":
+                    cfg.setRestAcceptQueueSize(((Number) value).intValue());
+                    break;
+                case "searchableTracesTags":
+                    cfg.setSearchableTracesTags((String) value);
+                    break;
+                case "sampleRate":
+                    cfg.setSampleRate(((Number) value).intValue());
+                    break;
+                case "maxSpansPerSecond":
+                    cfg.setMaxSpansPerSecond(((Number) value).intValue());
+                    break;
+                case "enableKafkaCollector":
+                    cfg.setEnableKafkaCollector((boolean) value);
+                    break;
+                case "kafkaBootstrapServers":
+                    cfg.setKafkaBootstrapServers((String) value);
+                    break;
+                case "kafkaGroupId":
+                    cfg.setKafkaGroupId((String) value);
+                    break;
+                case "kafkaTopic":
+                    cfg.setKafkaTopic((String) value);
+                    break;
+                case "kafkaConsumerConfig":
+                    cfg.setKafkaConsumerConfig((String) value);
+                    break;
+                case "kafkaConsumers":
+                    cfg.setKafkaConsumers(((Number) value).intValue());
+                    break;
+                case "kafkaHandlerThreadPoolSize":
+                    cfg.setKafkaHandlerThreadPoolSize(((Number) value).intValue());
+                    break;
+                case "kafkaHandlerThreadPoolQueueSize":
+                    cfg.setKafkaHandlerThreadPoolQueueSize(((Number) value).intValue());
+                    break;
+                default:
+                    log.warn("{} setting is not supported in {} provider of {} module",
+                        key, providerName, moduleName);
+                    break;
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void copyToGenAIConfig(
+            final GenAIConfig cfg, final Properties src,
+            final String moduleName, final String providerName) {
+        final Enumeration<?> propertyNames = src.propertyNames();
+        while (propertyNames.hasMoreElements()) {
+            final String key = (String) propertyNames.nextElement();
+            final Object value = src.get(key);
+            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
+            switch (key) {
+                case "providers":
+                    cfg.setProviders((List) value);
+                    break;
+                default:
+                    log.warn("{} setting is not supported in {} provider of {} module",
+                        key, providerName, moduleName);
+                    break;
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void copyToZipkinQueryConfig(
+            final ZipkinQueryConfig cfg, final Properties src,
+            final String moduleName, final String providerName) {
+        final Enumeration<?> propertyNames = src.propertyNames();
+        while (propertyNames.hasMoreElements()) {
+            final String key = (String) propertyNames.nextElement();
+            final Object value = src.get(key);
+            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
+            switch (key) {
+                case "restHost":
+                    cfg.setRestHost((String) value);
+                    break;
+                case "restPort":
+                    cfg.setRestPort(((Number) value).intValue());
+                    break;
+                case "restContextPath":
+                    cfg.setRestContextPath((String) value);
+                    break;
+                case "restIdleTimeOut":
+                    cfg.setRestIdleTimeOut(((Number) value).longValue());
+                    break;
+                case "restAcceptQueueSize":
+                    cfg.setRestAcceptQueueSize(((Number) value).intValue());
+                    break;
+                case "lookback":
+                    cfg.setLookback(((Number) value).longValue());
+                    break;
+                case "namesMaxAge":
+                    cfg.setNamesMaxAge(((Number) value).intValue());
+                    break;
+                case "uiQueryLimit":
+                    cfg.setUiQueryLimit(((Number) value).intValue());
+                    break;
+                case "uiEnvironment":
+                    cfg.setUiEnvironment((String) value);
+                    break;
+                case "uiDefaultLookback":
+                    cfg.setUiDefaultLookback(((Number) value).longValue());
+                    break;
+                case "uiSearchEnabled":
+                    cfg.setUiSearchEnabled((boolean) value);
+                    break;
+                default:
+                    log.warn("{} setting is not supported in {} provider of {} module",
+                        key, providerName, moduleName);
+                    break;
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void copyToStatusQueryConfig(
+            final StatusQueryConfig cfg, final Properties src,
+            final String moduleName, final String providerName) {
+        final Enumeration<?> propertyNames = src.propertyNames();
+        while (propertyNames.hasMoreElements()) {
+            final String key = (String) propertyNames.nextElement();
+            final Object value = src.get(key);
+            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
+            switch (key) {
+                case "keywords4MaskingSecretsOfConfig":
+                    cfg.setKeywords4MaskingSecretsOfConfig((String) value);
                     break;
                 default:
                     log.warn("{} setting is not supported in {} provider of {} module",
@@ -1365,6 +808,39 @@ public class YamlConfigLoaderUtils {
     }
 
     @SuppressWarnings("unchecked")
+    private static void copyToLogAnalyzerModuleConfig(
+            final LogAnalyzerModuleConfig cfg, final Properties src,
+            final String moduleName, final String providerName) {
+        final Enumeration<?> propertyNames = src.propertyNames();
+        while (propertyNames.hasMoreElements()) {
+            final String key = (String) propertyNames.nextElement();
+            final Object value = src.get(key);
+            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
+            switch (key) {
+                case "lalPath":
+                    cfg.setLalPath((String) value);
+                    break;
+                case "malPath":
+                    cfg.setMalPath((String) value);
+                    break;
+                case "lalFiles":
+                    cfg.setLalFiles((String) value);
+                    break;
+                case "malFiles":
+                    cfg.setMalFiles((String) value);
+                    break;
+                case "meterConfigs":
+                    cfg.setMeterConfigs((List) value);
+                    break;
+                default:
+                    log.warn("{} setting is not supported in {} provider of {} module",
+                        key, providerName, moduleName);
+                    break;
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
     private static void copyToOtelMetricReceiverConfig(
             final OtelMetricReceiverConfig cfg, final Properties src,
             final String moduleName, final String providerName) {
@@ -1379,6 +855,75 @@ public class YamlConfigLoaderUtils {
                     break;
                 case "enabledOtelMetricsRules":
                     cfg.setEnabledOtelMetricsRules((String) value);
+                    break;
+                default:
+                    log.warn("{} setting is not supported in {} provider of {} module",
+                        key, providerName, moduleName);
+                    break;
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void copyToBrowserServiceModuleConfig(
+            final BrowserServiceModuleConfig cfg, final Properties src,
+            final String moduleName, final String providerName) {
+        final Enumeration<?> propertyNames = src.propertyNames();
+        while (propertyNames.hasMoreElements()) {
+            final String key = (String) propertyNames.nextElement();
+            final Object value = src.get(key);
+            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
+            switch (key) {
+                case "sampleRate":
+                    cfg.setSampleRate(((Number) value).intValue());
+                    break;
+                default:
+                    log.warn("{} setting is not supported in {} provider of {} module",
+                        key, providerName, moduleName);
+                    break;
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void copyToConfigurationDiscoveryModuleConfig(
+            final ConfigurationDiscoveryModuleConfig cfg, final Properties src,
+            final String moduleName, final String providerName) {
+        final Enumeration<?> propertyNames = src.propertyNames();
+        while (propertyNames.hasMoreElements()) {
+            final String key = (String) propertyNames.nextElement();
+            final Object value = src.get(key);
+            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
+            switch (key) {
+                case "disableMessageDigest":
+                    cfg.setDisableMessageDigest((boolean) value);
+                    break;
+                default:
+                    log.warn("{} setting is not supported in {} provider of {} module",
+                        key, providerName, moduleName);
+                    break;
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void copyToZabbixModuleConfig(
+            final ZabbixModuleConfig cfg, final Properties src,
+            final String moduleName, final String providerName) {
+        final Enumeration<?> propertyNames = src.propertyNames();
+        while (propertyNames.hasMoreElements()) {
+            final String key = (String) propertyNames.nextElement();
+            final Object value = src.get(key);
+            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
+            switch (key) {
+                case "port":
+                    cfg.setPort(((Number) value).intValue());
+                    break;
+                case "host":
+                    cfg.setHost((String) value);
+                    break;
+                case "activeFiles":
+                    cfg.setActiveFiles((String) value);
                     break;
                 default:
                     log.warn("{} setting is not supported in {} provider of {} module",
@@ -1437,6 +982,75 @@ public class YamlConfigLoaderUtils {
     }
 
     @SuppressWarnings("unchecked")
+    private static void copyToAsyncProfilerModuleConfig(
+            final AsyncProfilerModuleConfig cfg, final Properties src,
+            final String moduleName, final String providerName) {
+        final Enumeration<?> propertyNames = src.propertyNames();
+        while (propertyNames.hasMoreElements()) {
+            final String key = (String) propertyNames.nextElement();
+            final Object value = src.get(key);
+            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
+            switch (key) {
+                case "jfrMaxSize":
+                    cfg.setJfrMaxSize(((Number) value).intValue());
+                    break;
+                case "memoryParserEnabled":
+                    cfg.setMemoryParserEnabled((boolean) value);
+                    break;
+                default:
+                    log.warn("{} setting is not supported in {} provider of {} module",
+                        key, providerName, moduleName);
+                    break;
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void copyToPprofModuleConfig(
+            final PprofModuleConfig cfg, final Properties src,
+            final String moduleName, final String providerName) {
+        final Enumeration<?> propertyNames = src.propertyNames();
+        while (propertyNames.hasMoreElements()) {
+            final String key = (String) propertyNames.nextElement();
+            final Object value = src.get(key);
+            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
+            switch (key) {
+                case "pprofMaxSize":
+                    cfg.setPprofMaxSize(((Number) value).intValue());
+                    break;
+                case "memoryParserEnabled":
+                    cfg.setMemoryParserEnabled((boolean) value);
+                    break;
+                default:
+                    log.warn("{} setting is not supported in {} provider of {} module",
+                        key, providerName, moduleName);
+                    break;
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void copyToTelegrafModuleConfig(
+            final TelegrafModuleConfig cfg, final Properties src,
+            final String moduleName, final String providerName) {
+        final Enumeration<?> propertyNames = src.propertyNames();
+        while (propertyNames.hasMoreElements()) {
+            final String key = (String) propertyNames.nextElement();
+            final Object value = src.get(key);
+            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
+            switch (key) {
+                case "activeFiles":
+                    cfg.setActiveFiles((String) value);
+                    break;
+                default:
+                    log.warn("{} setting is not supported in {} provider of {} module",
+                        key, providerName, moduleName);
+                    break;
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
     private static void copyToAWSFirehoseReceiverModuleConfig(
             final AWSFirehoseReceiverModuleConfig cfg, final Properties src,
             final String moduleName, final String providerName) {
@@ -1475,6 +1089,87 @@ public class YamlConfigLoaderUtils {
                     break;
                 case "tlsCertChainPath":
                     cfg.setTlsCertChainPath((String) value);
+                    break;
+                default:
+                    log.warn("{} setting is not supported in {} provider of {} module",
+                        key, providerName, moduleName);
+                    break;
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void copyToKafkaFetcherConfig(
+            final KafkaFetcherConfig cfg, final Properties src,
+            final String moduleName, final String providerName) {
+        final Enumeration<?> propertyNames = src.propertyNames();
+        while (propertyNames.hasMoreElements()) {
+            final String key = (String) propertyNames.nextElement();
+            final Object value = src.get(key);
+            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
+            switch (key) {
+                case "kafkaConsumerConfig":
+                    cfg.setKafkaConsumerConfig((Properties) value);
+                    break;
+                case "bootstrapServers":
+                    cfg.setBootstrapServers((String) value);
+                    break;
+                case "groupId":
+                    cfg.setGroupId((String) value);
+                    break;
+                case "partitions":
+                    cfg.setPartitions(((Number) value).intValue());
+                    break;
+                case "replicationFactor":
+                    cfg.setReplicationFactor(((Number) value).intValue());
+                    break;
+                case "enableNativeProtoLog":
+                    cfg.setEnableNativeProtoLog((boolean) value);
+                    break;
+                case "enableNativeJsonLog":
+                    cfg.setEnableNativeJsonLog((boolean) value);
+                    break;
+                case "configPath":
+                    cfg.setConfigPath((String) value);
+                    break;
+                case "topicNameOfMetrics":
+                    cfg.setTopicNameOfMetrics((String) value);
+                    break;
+                case "topicNameOfProfiling":
+                    cfg.setTopicNameOfProfiling((String) value);
+                    break;
+                case "topicNameOfTracingSegments":
+                    cfg.setTopicNameOfTracingSegments((String) value);
+                    break;
+                case "topicNameOfManagements":
+                    cfg.setTopicNameOfManagements((String) value);
+                    break;
+                case "topicNameOfMeters":
+                    cfg.setTopicNameOfMeters((String) value);
+                    break;
+                case "topicNameOfLogs":
+                    cfg.setTopicNameOfLogs((String) value);
+                    break;
+                case "topicNameOfJsonLogs":
+                    cfg.setTopicNameOfJsonLogs((String) value);
+                    break;
+                case "kafkaHandlerThreadPoolSize":
+                    cfg.setKafkaHandlerThreadPoolSize(((Number) value).intValue());
+                    break;
+                case "kafkaHandlerThreadPoolQueueSize":
+                    cfg.setKafkaHandlerThreadPoolQueueSize(((Number) value).intValue());
+                    break;
+                case "namespace":
+                    cfg.setNamespace((String) value);
+                    break;
+                case "mm2SourceAlias":
+                    cfg.setMm2SourceAlias((String) value);
+                    break;
+                case "mm2SourceSeparator":
+                    cfg.setMm2SourceSeparator((String) value);
+                    break;
+                case "consumers":
+                    cfg.setConsumers(((Number) value).intValue());
                     break;
                 default:
                     log.warn("{} setting is not supported in {} provider of {} module",
@@ -1527,8 +1222,8 @@ public class YamlConfigLoaderUtils {
     }
 
     @SuppressWarnings("unchecked")
-    private static void copyToStatusQueryConfig(
-            final StatusQueryConfig cfg, final Properties src,
+    private static void copyToBanyanDBStorageConfig(
+            final BanyanDBStorageConfig cfg, final Properties src,
             final String moduleName, final String providerName) {
         final Enumeration<?> propertyNames = src.propertyNames();
         while (propertyNames.hasMoreElements()) {
@@ -1536,8 +1231,77 @@ public class YamlConfigLoaderUtils {
             final Object value = src.get(key);
             log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
             switch (key) {
-                case "keywords4MaskingSecretsOfConfig":
-                    cfg.setKeywords4MaskingSecretsOfConfig((String) value);
+                case "global":
+                    cfg.setGlobal((BanyanDBStorageConfig.Global) value);
+                    break;
+                case "recordsNormal":
+                    cfg.setRecordsNormal((BanyanDBStorageConfig.RecordsNormal) value);
+                    break;
+                case "trace":
+                    cfg.setTrace((BanyanDBStorageConfig.Trace) value);
+                    break;
+                case "zipkinTrace":
+                    cfg.setZipkinTrace((BanyanDBStorageConfig.ZipkinTrace) value);
+                    break;
+                case "recordsTrace":
+                    cfg.setRecordsTrace((BanyanDBStorageConfig.RecordsTrace) value);
+                    break;
+                case "recordsZipkinTrace":
+                    cfg.setRecordsZipkinTrace((BanyanDBStorageConfig.RecordsZipkinTrace) value);
+                    break;
+                case "recordsLog":
+                    cfg.setRecordsLog((BanyanDBStorageConfig.RecordsLog) value);
+                    break;
+                case "recordsBrowserErrorLog":
+                    cfg.setRecordsBrowserErrorLog((BanyanDBStorageConfig.RecordsBrowserErrorLog) value);
+                    break;
+                case "metricsMin":
+                    cfg.setMetricsMin((BanyanDBStorageConfig.MetricsMin) value);
+                    break;
+                case "metricsHour":
+                    cfg.setMetricsHour((BanyanDBStorageConfig.MetricsHour) value);
+                    break;
+                case "metricsDay":
+                    cfg.setMetricsDay((BanyanDBStorageConfig.MetricsDay) value);
+                    break;
+                case "metadata":
+                    cfg.setMetadata((BanyanDBStorageConfig.Metadata) value);
+                    break;
+                case "property":
+                    cfg.setProperty((BanyanDBStorageConfig.Property) value);
+                    break;
+                case "topNConfigs":
+                    cfg.setTopNConfigs((Map) value);
+                    break;
+                default:
+                    log.warn("{} setting is not supported in {} provider of {} module",
+                        key, providerName, moduleName);
+                    break;
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void copyToGraphQLQueryConfig(
+            final GraphQLQueryConfig cfg, final Properties src,
+            final String moduleName, final String providerName) {
+        final Enumeration<?> propertyNames = src.propertyNames();
+        while (propertyNames.hasMoreElements()) {
+            final String key = (String) propertyNames.nextElement();
+            final Object value = src.get(key);
+            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
+            switch (key) {
+                case "enableLogTestTool":
+                    cfg.setEnableLogTestTool((boolean) value);
+                    break;
+                case "maxQueryComplexity":
+                    cfg.setMaxQueryComplexity(((Number) value).intValue());
+                    break;
+                case "enableUpdateUITemplate":
+                    cfg.setEnableUpdateUITemplate((boolean) value);
+                    break;
+                case "enableOnDemandPodLog":
+                    cfg.setEnableOnDemandPodLog((boolean) value);
                     break;
                 default:
                     log.warn("{} setting is not supported in {} provider of {} module",
@@ -1559,6 +1323,342 @@ public class YamlConfigLoaderUtils {
             switch (key) {
                 case "checkIntervalSeconds":
                     cfg.setCheckIntervalSeconds(((Number) value).longValue());
+                    break;
+                default:
+                    log.warn("{} setting is not supported in {} provider of {} module",
+                        key, providerName, moduleName);
+                    break;
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void copyToAIPipelineConfig(
+            final AIPipelineConfig cfg, final Properties src,
+            final String moduleName, final String providerName) {
+        final Enumeration<?> propertyNames = src.propertyNames();
+        while (propertyNames.hasMoreElements()) {
+            final String key = (String) propertyNames.nextElement();
+            final Object value = src.get(key);
+            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
+            switch (key) {
+                case "uriRecognitionServerAddr":
+                    cfg.setUriRecognitionServerAddr((String) value);
+                    break;
+                case "uriRecognitionServerPort":
+                    cfg.setUriRecognitionServerPort(((Number) value).intValue());
+                    break;
+                case "baselineServerAddr":
+                    cfg.setBaselineServerAddr((String) value);
+                    break;
+                case "baselineServerPort":
+                    cfg.setBaselineServerPort(((Number) value).intValue());
+                    break;
+                default:
+                    log.warn("{} setting is not supported in {} provider of {} module",
+                        key, providerName, moduleName);
+                    break;
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void copyToPromQLConfig(
+            final PromQLConfig cfg, final Properties src,
+            final String moduleName, final String providerName) {
+        final Enumeration<?> propertyNames = src.propertyNames();
+        while (propertyNames.hasMoreElements()) {
+            final String key = (String) propertyNames.nextElement();
+            final Object value = src.get(key);
+            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
+            switch (key) {
+                case "restHost":
+                    cfg.setRestHost((String) value);
+                    break;
+                case "restPort":
+                    cfg.setRestPort(((Number) value).intValue());
+                    break;
+                case "restContextPath":
+                    cfg.setRestContextPath((String) value);
+                    break;
+                case "restIdleTimeOut":
+                    cfg.setRestIdleTimeOut(((Number) value).longValue());
+                    break;
+                case "restAcceptQueueSize":
+                    cfg.setRestAcceptQueueSize(((Number) value).intValue());
+                    break;
+                case "buildInfoVersion":
+                    cfg.setBuildInfoVersion((String) value);
+                    break;
+                case "buildInfoRevision":
+                    cfg.setBuildInfoRevision((String) value);
+                    break;
+                case "buildInfoBranch":
+                    cfg.setBuildInfoBranch((String) value);
+                    break;
+                case "buildInfoBuildUser":
+                    cfg.setBuildInfoBuildUser((String) value);
+                    break;
+                case "buildInfoBuildDate":
+                    cfg.setBuildInfoBuildDate((String) value);
+                    break;
+                case "buildInfoGoVersion":
+                    cfg.setBuildInfoGoVersion((String) value);
+                    break;
+                default:
+                    log.warn("{} setting is not supported in {} provider of {} module",
+                        key, providerName, moduleName);
+                    break;
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void copyToLogQLConfig(
+            final LogQLConfig cfg, final Properties src,
+            final String moduleName, final String providerName) {
+        final Enumeration<?> propertyNames = src.propertyNames();
+        while (propertyNames.hasMoreElements()) {
+            final String key = (String) propertyNames.nextElement();
+            final Object value = src.get(key);
+            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
+            switch (key) {
+                case "restHost":
+                    cfg.setRestHost((String) value);
+                    break;
+                case "restPort":
+                    cfg.setRestPort(((Number) value).intValue());
+                    break;
+                case "restContextPath":
+                    cfg.setRestContextPath((String) value);
+                    break;
+                case "restIdleTimeOut":
+                    cfg.setRestIdleTimeOut(((Number) value).longValue());
+                    break;
+                case "restAcceptQueueSize":
+                    cfg.setRestAcceptQueueSize(((Number) value).intValue());
+                    break;
+                default:
+                    log.warn("{} setting is not supported in {} provider of {} module",
+                        key, providerName, moduleName);
+                    break;
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void copyToTraceQLConfig(
+            final TraceQLConfig cfg, final Properties src,
+            final String moduleName, final String providerName) {
+        final Enumeration<?> propertyNames = src.propertyNames();
+        while (propertyNames.hasMoreElements()) {
+            final String key = (String) propertyNames.nextElement();
+            final Object value = src.get(key);
+            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
+            switch (key) {
+                case "restHost":
+                    cfg.setRestHost((String) value);
+                    break;
+                case "restPort":
+                    cfg.setRestPort(((Number) value).intValue());
+                    break;
+                case "enableDatasourceZipkin":
+                    cfg.setEnableDatasourceZipkin((boolean) value);
+                    break;
+                case "enableDatasourceSkywalking":
+                    cfg.setEnableDatasourceSkywalking((boolean) value);
+                    break;
+                case "restContextPathZipkin":
+                    cfg.setRestContextPathZipkin((String) value);
+                    break;
+                case "restContextPathSkywalking":
+                    cfg.setRestContextPathSkywalking((String) value);
+                    break;
+                case "restIdleTimeOut":
+                    cfg.setRestIdleTimeOut(((Number) value).longValue());
+                    break;
+                case "restAcceptQueueSize":
+                    cfg.setRestAcceptQueueSize(((Number) value).intValue());
+                    break;
+                case "lookback":
+                    cfg.setLookback(((Number) value).longValue());
+                    break;
+                case "zipkinTracesListResultTags":
+                    cfg.setZipkinTracesListResultTags((String) value);
+                    break;
+                case "skywalkingTracesListResultTags":
+                    cfg.setSkywalkingTracesListResultTags((String) value);
+                    break;
+                default:
+                    log.warn("{} setting is not supported in {} provider of {} module",
+                        key, providerName, moduleName);
+                    break;
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void copyToPrometheusConfig(
+            final PrometheusConfig cfg, final Properties src,
+            final String moduleName, final String providerName) {
+        final Enumeration<?> propertyNames = src.propertyNames();
+        while (propertyNames.hasMoreElements()) {
+            final String key = (String) propertyNames.nextElement();
+            final Object value = src.get(key);
+            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
+            switch (key) {
+                case "host":
+                    cfg.setHost((String) value);
+                    break;
+                case "port":
+                    cfg.setPort(((Number) value).intValue());
+                    break;
+                case "sslEnabled":
+                    cfg.setSslEnabled((boolean) value);
+                    break;
+                case "sslKeyPath":
+                    cfg.setSslKeyPath((String) value);
+                    break;
+                case "sslCertChainPath":
+                    cfg.setSslCertChainPath((String) value);
+                    break;
+                default:
+                    log.warn("{} setting is not supported in {} provider of {} module",
+                        key, providerName, moduleName);
+                    break;
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void copyToExporterSetting(
+            final ExporterSetting cfg, final Properties src,
+            final String moduleName, final String providerName) {
+        final Enumeration<?> propertyNames = src.propertyNames();
+        while (propertyNames.hasMoreElements()) {
+            final String key = (String) propertyNames.nextElement();
+            final Object value = src.get(key);
+            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
+            switch (key) {
+                case "enableGRPCMetrics":
+                    cfg.setEnableGRPCMetrics((boolean) value);
+                    break;
+                case "gRPCTargetHost":
+                    cfg.setGRPCTargetHost((String) value);
+                    break;
+                case "gRPCTargetPort":
+                    cfg.setGRPCTargetPort(((Number) value).intValue());
+                    break;
+                case "bufferSize":
+                    cfg.setBufferSize(((Number) value).intValue());
+                    break;
+                case "enableKafkaTrace":
+                    cfg.setEnableKafkaTrace((boolean) value);
+                    break;
+                case "enableKafkaLog":
+                    cfg.setEnableKafkaLog((boolean) value);
+                    break;
+                case "kafkaBootstrapServers":
+                    cfg.setKafkaBootstrapServers((String) value);
+                    break;
+                case "kafkaProducerConfig":
+                    cfg.setKafkaProducerConfig((String) value);
+                    break;
+                case "kafkaTopicTrace":
+                    cfg.setKafkaTopicTrace((String) value);
+                    break;
+                case "kafkaTopicLog":
+                    cfg.setKafkaTopicLog((String) value);
+                    break;
+                case "exportErrorStatusTraceOnly":
+                    cfg.setExportErrorStatusTraceOnly((boolean) value);
+                    break;
+                default:
+                    log.warn("{} setting is not supported in {} provider of {} module",
+                        key, providerName, moduleName);
+                    break;
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void copyToConfigmapConfigurationSettings(
+            final ConfigmapConfigurationSettings cfg, final Properties src,
+            final String moduleName, final String providerName) {
+        final Enumeration<?> propertyNames = src.propertyNames();
+        while (propertyNames.hasMoreElements()) {
+            final String key = (String) propertyNames.nextElement();
+            final Object value = src.get(key);
+            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
+            switch (key) {
+                case "namespace":
+                    cfg.setNamespace((String) value);
+                    break;
+                case "labelSelector":
+                    cfg.setLabelSelector((String) value);
+                    break;
+                case "period":
+                    cfg.setPeriod((Integer) value);
+                    break;
+                default:
+                    log.warn("{} setting is not supported in {} provider of {} module",
+                        key, providerName, moduleName);
+                    break;
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void copyToModel(
+            final GenAIConfig.Model cfg, final Properties src,
+            final String moduleName, final String providerName) {
+        final Enumeration<?> propertyNames = src.propertyNames();
+        while (propertyNames.hasMoreElements()) {
+            final String key = (String) propertyNames.nextElement();
+            final Object value = src.get(key);
+            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
+            switch (key) {
+                case "name":
+                    cfg.setName((String) value);
+                    break;
+                case "aliases":
+                    cfg.setAliases((List) value);
+                    break;
+                case "inputEstimatedCostPerM":
+                    cfg.setInputEstimatedCostPerM(((Number) value).doubleValue());
+                    break;
+                case "outputEstimatedCostPerM":
+                    cfg.setOutputEstimatedCostPerM(((Number) value).doubleValue());
+                    break;
+                default:
+                    log.warn("{} setting is not supported in {} provider of {} module",
+                        key, providerName, moduleName);
+                    break;
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void copyToProvider(
+            final GenAIConfig.Provider cfg, final Properties src,
+            final String moduleName, final String providerName) {
+        final Enumeration<?> propertyNames = src.propertyNames();
+        while (propertyNames.hasMoreElements()) {
+            final String key = (String) propertyNames.nextElement();
+            final Object value = src.get(key);
+            log.debug("{}.{} config: {} = {}", moduleName, providerName, key, value);
+            switch (key) {
+                case "provider":
+                    cfg.setProvider((String) value);
+                    break;
+                case "baseUrl":
+                    cfg.setBaseUrl((String) value);
+                    break;
+                case "prefixMatch":
+                    cfg.setPrefixMatch((List) value);
+                    break;
+                case "models":
+                    cfg.setModels((List) value);
                     break;
                 default:
                     log.warn("{} setting is not supported in {} provider of {} module",

--- a/oap-graalvm-server/src/main/resources/application.yml
+++ b/oap-graalvm-server/src/main/resources/application.yml
@@ -100,11 +100,15 @@ agent-analyzer:
 log-analyzer:
   selector: ${SW_LOG_ANALYZER:default}
   default:
-    lalFiles: ${SW_LOG_LAL_FILES:envoy-als,mesh-dp,mysql-slowsql,pgsql-slowsql,redis-slowsql,k8s-service,nginx,default}
+    lalFiles: ${SW_LOG_LAL_FILES:envoy-als,mesh-dp,mysql-slowsql,pgsql-slowsql,redis-slowsql,k8s-service,nginx,envoy-ai-gateway,default}
     malFiles: ${SW_LOG_MAL_FILES:"nginx"}
 
 event-analyzer:
   selector: ${SW_EVENT_ANALYZER:default}
+  default:
+
+gen-ai-analyzer:
+  selector: ${SW_GENAI_ANALYZER:default}
   default:
 
 receiver-sharing-server:
@@ -223,7 +227,7 @@ receiver-otel:
   selector: ${SW_OTEL_RECEIVER:default}
   default:
     enabledHandlers: ${SW_OTEL_RECEIVER_ENABLED_HANDLERS:"otlp-traces,otlp-metrics,otlp-logs"}
-    enabledOtelMetricsRules: ${SW_OTEL_RECEIVER_ENABLED_OTEL_METRICS_RULES:"apisix,nginx/*,k8s/*,istio-controlplane,vm,mysql/*,postgresql/*,oap,aws-eks/*,windows,aws-s3/*,aws-dynamodb/*,aws-gateway/*,redis/*,elasticsearch/*,rabbitmq/*,mongodb/*,kafka/*,pulsar/*,bookkeeper/*,rocketmq/*,clickhouse/*,activemq/*,kong/*,flink/*,banyandb/*"}
+    enabledOtelMetricsRules: ${SW_OTEL_RECEIVER_ENABLED_OTEL_METRICS_RULES:"apisix,nginx/*,k8s/*,istio-controlplane,vm,mysql/*,postgresql/*,oap,aws-eks/*,windows,aws-s3/*,aws-dynamodb/*,aws-gateway/*,redis/*,elasticsearch/*,rabbitmq/*,mongodb/*,kafka/*,pulsar/*,bookkeeper/*,rocketmq/*,clickhouse/*,activemq/*,kong/*,flink/*,banyandb/*,envoy-ai-gateway/*"}
 
 receiver-zipkin:
   selector: ${SW_RECEIVER_ZIPKIN:-}
@@ -311,6 +315,9 @@ traceQL:
     restContextPathSkywalking: ${SW_TRACEQL_REST_CONTEXT_PATH_SKYWALKING:/skywalking}
     restIdleTimeOut: ${SW_TRACEQL_REST_IDLE_TIMEOUT:30000}
     restAcceptQueueSize: ${SW_TRACEQL_REST_QUEUE_SIZE:0}
+    lookback: ${SW_TRACEQL_LOOKBACK:86400000}
+    zipkinTracesListResultTags: ${SW_TRACEQL_ZIPKIN_TRACES_LIST_RESULT_TAGS:http.method,error}
+    skywalkingTracesListResultTags: ${SW_TRACEQL_SKYWALKING_TRACES_LIST_RESULT_TAGS:http.method,http.status_code,rpc.status_code,db.type,db.instance,mq.queue,mq.topic,mq.broker}
 
 alarm:
   selector: ${SW_ALARM:default}

--- a/oap-graalvm-server/src/test/java/org/apache/skywalking/oap/server/graalvm/mal/EnvoyAIGatewayInstanceTest.java
+++ b/oap-graalvm-server/src/test/java/org/apache/skywalking/oap/server/graalvm/mal/EnvoyAIGatewayInstanceTest.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.skywalking.oap.server.graalvm.mal;
+
+import com.google.common.collect.ImmutableMap;
+import java.time.Instant;
+import java.util.stream.Stream;
+import org.apache.skywalking.oap.meter.analyzer.v2.dsl.Sample;
+import org.apache.skywalking.oap.meter.analyzer.v2.dsl.SampleFamily;
+import org.apache.skywalking.oap.meter.analyzer.v2.dsl.SampleFamilyBuilder;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+class EnvoyAIGatewayInstanceTest extends MALScriptComparisonBase {
+
+    private static final String YAML_PATH =
+        "otel-rules/envoy-ai-gateway/gateway-instance.yaml";
+    private static final long TS1 =
+        Instant.parse("2024-01-01T00:00:00Z").toEpochMilli();
+    private static final long TS2 =
+        Instant.parse("2024-01-01T00:02:00Z").toEpochMilli();
+
+    @TestFactory
+    Stream<DynamicTest> allMetrics() {
+        return generateComparisonTests(YAML_PATH,
+            buildInput(100.0, TS1), buildInput(200.0, TS2));
+    }
+
+    private static ImmutableMap<String, SampleFamily> buildInput(
+            final double base, final long timestamp) {
+        double scale = base / 100.0;
+        ImmutableMap<String, String> scope = ImmutableMap.of(
+            "service_name", "e2e-ai-gateway",
+            "service_instance_id", "aigw-1",
+            "job_name", "envoy-ai-gateway");
+
+        ImmutableMap<String, String> providerScope = ImmutableMap.<String, String>builder()
+            .putAll(scope)
+            .put("gen_ai_provider_name", "openai")
+            .build();
+
+        ImmutableMap<String, String> modelScope = ImmutableMap.<String, String>builder()
+            .putAll(scope)
+            .put("gen_ai_response_model", "gpt-4o-mini")
+            .build();
+
+        return ImmutableMap.<String, SampleFamily>builder()
+            .put("gen_ai_server_request_duration_count",
+                SampleFamilyBuilder.newBuilder(
+                    sample("gen_ai_server_request_duration_count", scope, 50.0 * scale, timestamp),
+                    sample("gen_ai_server_request_duration_count", providerScope, 50.0 * scale, timestamp),
+                    sample("gen_ai_server_request_duration_count", modelScope, 50.0 * scale, timestamp)
+                ).build())
+            .put("gen_ai_server_request_duration_sum",
+                SampleFamilyBuilder.newBuilder(
+                    sample("gen_ai_server_request_duration_sum", scope, 25.0 * scale, timestamp),
+                    sample("gen_ai_server_request_duration_sum", providerScope, 25.0 * scale, timestamp),
+                    sample("gen_ai_server_request_duration_sum", modelScope, 25.0 * scale, timestamp)
+                ).build())
+            .put("gen_ai_server_request_duration",
+                SampleFamilyBuilder.newBuilder(
+                    histSample("gen_ai_server_request_duration", scope, "0.1", 10.0 * scale, timestamp),
+                    histSample("gen_ai_server_request_duration", scope, "0.5", 30.0 * scale, timestamp),
+                    histSample("gen_ai_server_request_duration", scope, "1.0", 45.0 * scale, timestamp),
+                    histSample("gen_ai_server_request_duration", scope, "10.0", 50.0 * scale, timestamp)
+                ).build())
+            .put("gen_ai_client_token_usage_sum",
+                SampleFamilyBuilder.newBuilder(
+                    tokenSample(scope, "input", 5000.0 * scale, timestamp),
+                    tokenSample(scope, "output", 3000.0 * scale, timestamp),
+                    tokenSample(providerScope, "input", 5000.0 * scale, timestamp),
+                    tokenSample(providerScope, "output", 3000.0 * scale, timestamp),
+                    tokenSample(modelScope, "input", 5000.0 * scale, timestamp),
+                    tokenSample(modelScope, "output", 3000.0 * scale, timestamp)
+                ).build())
+            .put("gen_ai_server_time_to_first_token_count",
+                SampleFamilyBuilder.newBuilder(
+                    sample("gen_ai_server_time_to_first_token_count", scope, 40.0 * scale, timestamp),
+                    sample("gen_ai_server_time_to_first_token_count", modelScope, 40.0 * scale, timestamp)
+                ).build())
+            .put("gen_ai_server_time_to_first_token_sum",
+                SampleFamilyBuilder.newBuilder(
+                    sample("gen_ai_server_time_to_first_token_sum", scope, 8.0 * scale, timestamp),
+                    sample("gen_ai_server_time_to_first_token_sum", modelScope, 8.0 * scale, timestamp)
+                ).build())
+            .put("gen_ai_server_time_to_first_token",
+                SampleFamilyBuilder.newBuilder(
+                    histSample("gen_ai_server_time_to_first_token", scope, "0.1", 10.0 * scale, timestamp),
+                    histSample("gen_ai_server_time_to_first_token", scope, "0.5", 30.0 * scale, timestamp),
+                    histSample("gen_ai_server_time_to_first_token", scope, "10.0", 40.0 * scale, timestamp)
+                ).build())
+            .put("gen_ai_server_time_per_output_token_count",
+                SampleFamilyBuilder.newBuilder(
+                    sample("gen_ai_server_time_per_output_token_count", scope, 40.0 * scale, timestamp),
+                    sample("gen_ai_server_time_per_output_token_count", modelScope, 40.0 * scale, timestamp)
+                ).build())
+            .put("gen_ai_server_time_per_output_token_sum",
+                SampleFamilyBuilder.newBuilder(
+                    sample("gen_ai_server_time_per_output_token_sum", scope, 2.0 * scale, timestamp),
+                    sample("gen_ai_server_time_per_output_token_sum", modelScope, 2.0 * scale, timestamp)
+                ).build())
+            .put("gen_ai_server_time_per_output_token",
+                SampleFamilyBuilder.newBuilder(
+                    histSample("gen_ai_server_time_per_output_token", scope, "0.01", 10.0 * scale, timestamp),
+                    histSample("gen_ai_server_time_per_output_token", scope, "0.05", 30.0 * scale, timestamp),
+                    histSample("gen_ai_server_time_per_output_token", scope, "1.0", 40.0 * scale, timestamp)
+                ).build())
+            .build();
+    }
+
+    private static Sample sample(final String name,
+                                  final ImmutableMap<String, String> labels,
+                                  final double value, final long timestamp) {
+        return Sample.builder()
+            .name(name).labels(labels).value(value).timestamp(timestamp).build();
+    }
+
+    private static Sample histSample(final String name,
+                                      final ImmutableMap<String, String> labels,
+                                      final String le, final double value,
+                                      final long timestamp) {
+        return Sample.builder()
+            .name(name)
+            .labels(ImmutableMap.<String, String>builder()
+                .putAll(labels).put("le", le).build())
+            .value(value).timestamp(timestamp).build();
+    }
+
+    private static Sample tokenSample(final ImmutableMap<String, String> labels,
+                                       final String tokenType, final double value,
+                                       final long timestamp) {
+        return Sample.builder()
+            .name("gen_ai_client_token_usage_sum")
+            .labels(ImmutableMap.<String, String>builder()
+                .putAll(labels).put("gen_ai_token_type", tokenType).build())
+            .value(value).timestamp(timestamp).build();
+    }
+}

--- a/oap-graalvm-server/src/test/java/org/apache/skywalking/oap/server/graalvm/mal/EnvoyAIGatewayServiceTest.java
+++ b/oap-graalvm-server/src/test/java/org/apache/skywalking/oap/server/graalvm/mal/EnvoyAIGatewayServiceTest.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.skywalking.oap.server.graalvm.mal;
+
+import com.google.common.collect.ImmutableMap;
+import java.time.Instant;
+import java.util.stream.Stream;
+import org.apache.skywalking.oap.meter.analyzer.v2.dsl.Sample;
+import org.apache.skywalking.oap.meter.analyzer.v2.dsl.SampleFamily;
+import org.apache.skywalking.oap.meter.analyzer.v2.dsl.SampleFamilyBuilder;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+class EnvoyAIGatewayServiceTest extends MALScriptComparisonBase {
+
+    private static final String YAML_PATH =
+        "otel-rules/envoy-ai-gateway/gateway-service.yaml";
+    private static final long TS1 =
+        Instant.parse("2024-01-01T00:00:00Z").toEpochMilli();
+    private static final long TS2 =
+        Instant.parse("2024-01-01T00:02:00Z").toEpochMilli();
+
+    @TestFactory
+    Stream<DynamicTest> allMetrics() {
+        return generateComparisonTests(YAML_PATH,
+            buildInput(100.0, TS1), buildInput(200.0, TS2));
+    }
+
+    private static ImmutableMap<String, SampleFamily> buildInput(
+            final double base, final long timestamp) {
+        double scale = base / 100.0;
+        ImmutableMap<String, String> scope = ImmutableMap.of(
+            "service_name", "e2e-ai-gateway",
+            "job_name", "envoy-ai-gateway");
+
+        ImmutableMap<String, String> providerScope = ImmutableMap.<String, String>builder()
+            .putAll(scope)
+            .put("gen_ai_provider_name", "openai")
+            .build();
+
+        ImmutableMap<String, String> modelScope = ImmutableMap.<String, String>builder()
+            .putAll(scope)
+            .put("gen_ai_response_model", "gpt-4o-mini")
+            .build();
+
+        return ImmutableMap.<String, SampleFamily>builder()
+            .put("gen_ai_server_request_duration_count",
+                SampleFamilyBuilder.newBuilder(
+                    sample("gen_ai_server_request_duration_count", scope, 50.0 * scale, timestamp),
+                    sample("gen_ai_server_request_duration_count", providerScope, 50.0 * scale, timestamp),
+                    sample("gen_ai_server_request_duration_count", modelScope, 50.0 * scale, timestamp)
+                ).build())
+            .put("gen_ai_server_request_duration_sum",
+                SampleFamilyBuilder.newBuilder(
+                    sample("gen_ai_server_request_duration_sum", scope, 25.0 * scale, timestamp),
+                    sample("gen_ai_server_request_duration_sum", providerScope, 25.0 * scale, timestamp),
+                    sample("gen_ai_server_request_duration_sum", modelScope, 25.0 * scale, timestamp)
+                ).build())
+            .put("gen_ai_server_request_duration",
+                SampleFamilyBuilder.newBuilder(
+                    histSample("gen_ai_server_request_duration", scope, "0.1", 10.0 * scale, timestamp),
+                    histSample("gen_ai_server_request_duration", scope, "0.5", 30.0 * scale, timestamp),
+                    histSample("gen_ai_server_request_duration", scope, "1.0", 45.0 * scale, timestamp),
+                    histSample("gen_ai_server_request_duration", scope, "10.0", 50.0 * scale, timestamp)
+                ).build())
+            .put("gen_ai_client_token_usage_sum",
+                SampleFamilyBuilder.newBuilder(
+                    tokenSample(scope, "input", 5000.0 * scale, timestamp),
+                    tokenSample(scope, "output", 3000.0 * scale, timestamp),
+                    tokenSample(providerScope, "input", 5000.0 * scale, timestamp),
+                    tokenSample(providerScope, "output", 3000.0 * scale, timestamp),
+                    tokenSample(modelScope, "input", 5000.0 * scale, timestamp),
+                    tokenSample(modelScope, "output", 3000.0 * scale, timestamp)
+                ).build())
+            .put("gen_ai_server_time_to_first_token_count",
+                SampleFamilyBuilder.newBuilder(
+                    sample("gen_ai_server_time_to_first_token_count", scope, 40.0 * scale, timestamp),
+                    sample("gen_ai_server_time_to_first_token_count", modelScope, 40.0 * scale, timestamp)
+                ).build())
+            .put("gen_ai_server_time_to_first_token_sum",
+                SampleFamilyBuilder.newBuilder(
+                    sample("gen_ai_server_time_to_first_token_sum", scope, 8.0 * scale, timestamp),
+                    sample("gen_ai_server_time_to_first_token_sum", modelScope, 8.0 * scale, timestamp)
+                ).build())
+            .put("gen_ai_server_time_to_first_token",
+                SampleFamilyBuilder.newBuilder(
+                    histSample("gen_ai_server_time_to_first_token", scope, "0.1", 10.0 * scale, timestamp),
+                    histSample("gen_ai_server_time_to_first_token", scope, "0.5", 30.0 * scale, timestamp),
+                    histSample("gen_ai_server_time_to_first_token", scope, "10.0", 40.0 * scale, timestamp)
+                ).build())
+            .put("gen_ai_server_time_per_output_token_count",
+                SampleFamilyBuilder.newBuilder(
+                    sample("gen_ai_server_time_per_output_token_count", scope, 40.0 * scale, timestamp),
+                    sample("gen_ai_server_time_per_output_token_count", modelScope, 40.0 * scale, timestamp)
+                ).build())
+            .put("gen_ai_server_time_per_output_token_sum",
+                SampleFamilyBuilder.newBuilder(
+                    sample("gen_ai_server_time_per_output_token_sum", scope, 2.0 * scale, timestamp),
+                    sample("gen_ai_server_time_per_output_token_sum", modelScope, 2.0 * scale, timestamp)
+                ).build())
+            .put("gen_ai_server_time_per_output_token",
+                SampleFamilyBuilder.newBuilder(
+                    histSample("gen_ai_server_time_per_output_token", scope, "0.01", 10.0 * scale, timestamp),
+                    histSample("gen_ai_server_time_per_output_token", scope, "0.05", 30.0 * scale, timestamp),
+                    histSample("gen_ai_server_time_per_output_token", scope, "1.0", 40.0 * scale, timestamp)
+                ).build())
+            .build();
+    }
+
+    private static Sample sample(final String name,
+                                  final ImmutableMap<String, String> labels,
+                                  final double value, final long timestamp) {
+        return Sample.builder()
+            .name(name).labels(labels).value(value).timestamp(timestamp).build();
+    }
+
+    private static Sample histSample(final String name,
+                                      final ImmutableMap<String, String> labels,
+                                      final String le, final double value,
+                                      final long timestamp) {
+        return Sample.builder()
+            .name(name)
+            .labels(ImmutableMap.<String, String>builder()
+                .putAll(labels).put("le", le).build())
+            .value(value).timestamp(timestamp).build();
+    }
+
+    private static Sample tokenSample(final ImmutableMap<String, String> labels,
+                                       final String tokenType, final double value,
+                                       final long timestamp) {
+        return Sample.builder()
+            .name("gen_ai_client_token_usage_sum")
+            .labels(ImmutableMap.<String, String>builder()
+                .putAll(labels).put("gen_ai_token_type", tokenType).build())
+            .value(value).timestamp(timestamp).build();
+    }
+}

--- a/oap-graalvm-server/src/test/resources/provider-inventory.properties
+++ b/oap-graalvm-server/src/test/resources/provider-inventory.properties
@@ -57,6 +57,7 @@ provider.org.apache.skywalking.oap.server.telemetry.none.NoneTelemetryProvider =
 provider.org.apache.skywalking.oap.server.analyzer.provider.AnalyzerModuleProvider = ACCEPTED
 provider.org.apache.skywalking.oap.log.analyzer.v2.provider.LogAnalyzerModuleProvider = ACCEPTED
 provider.org.apache.skywalking.oap.server.analyzer.event.EventAnalyzerModuleProvider = ACCEPTED
+provider.org.apache.skywalking.oap.analyzer.genai.GenAIAnalyzerModuleProvider = ACCEPTED
 
 # --- Receivers ---
 provider.org.apache.skywalking.oap.server.receiver.sharing.server.SharingServerModuleProvider = ACCEPTED

--- a/oap-graalvm-server/src/test/resources/rule-file-inventory.properties
+++ b/oap-graalvm-server/src/test/resources/rule-file-inventory.properties
@@ -21,7 +21,7 @@
 # Format: relative/path = ACCEPTED
 # All rule files should be ACCEPTED (added to precompiler).
 
-# --- OAL scripts (9 files) ---
+# --- OAL scripts (10 files) ---
 oal/browser.oal = ACCEPTED
 oal/cilium.oal = ACCEPTED
 oal/core.oal = ACCEPTED
@@ -31,6 +31,7 @@ oal/ebpf.oal = ACCEPTED
 oal/java-agent.oal = ACCEPTED
 oal/mesh.oal = ACCEPTED
 oal/tcp.oal = ACCEPTED
+oal/virtual-gen-ai.oal = ACCEPTED
 
 # --- meter-analyzer-config (11 files) ---
 meter-analyzer-config/continuous-profiling.yaml = ACCEPTED
@@ -99,6 +100,8 @@ otel-rules/redis/redis-service.yaml = ACCEPTED
 otel-rules/rocketmq/rocketmq-broker.yaml = ACCEPTED
 otel-rules/rocketmq/rocketmq-cluster.yaml = ACCEPTED
 otel-rules/rocketmq/rocketmq-topic.yaml = ACCEPTED
+otel-rules/envoy-ai-gateway/gateway-instance.yaml = ACCEPTED
+otel-rules/envoy-ai-gateway/gateway-service.yaml = ACCEPTED
 otel-rules/vm.yaml = ACCEPTED
 otel-rules/windows.yaml = ACCEPTED
 
@@ -116,8 +119,9 @@ telegraf-rules/vm.yaml = ACCEPTED
 # --- zabbix-rules (1 file) ---
 zabbix-rules/agent.yaml = ACCEPTED
 
-# --- LAL (8 files) ---
+# --- LAL (9 files) ---
 lal/default.yaml = ACCEPTED
+lal/envoy-ai-gateway.yaml = ACCEPTED
 lal/envoy-als.yaml = ACCEPTED
 lal/k8s-service.yaml = ACCEPTED
 lal/mesh-dp.yaml = ACCEPTED

--- a/oap-libs-for-graalvm/log-analyzer-for-graalvm/pom.xml
+++ b/oap-libs-for-graalvm/log-analyzer-for-graalvm/pom.xml
@@ -66,6 +66,8 @@
                                 <exclude>org/apache/skywalking/oap/log/analyzer/v2/dsl/DSL$*.class</exclude>
                                 <exclude>org/apache/skywalking/oap/log/analyzer/v2/provider/LALConfigs.class</exclude>
                                 <exclude>org/apache/skywalking/oap/log/analyzer/v2/provider/LALConfigs$*.class</exclude>
+                                <exclude>org/apache/skywalking/oap/log/analyzer/v2/provider/LogAnalyzerModuleConfig.class</exclude>
+                                <exclude>org/apache/skywalking/oap/log/analyzer/v2/provider/LogAnalyzerModuleConfig$*.class</exclude>
                             </excludes>
                         </filter>
                     </filters>

--- a/oap-libs-for-graalvm/log-analyzer-for-graalvm/src/main/java/org/apache/skywalking/oap/log/analyzer/v2/provider/LogAnalyzerModuleConfig.java
+++ b/oap-libs-for-graalvm/log-analyzer-for-graalvm/src/main/java/org/apache/skywalking/oap/log/analyzer/v2/provider/LogAnalyzerModuleConfig.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.skywalking.oap.log.analyzer.v2.provider;
+
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+
+import java.io.IOException;
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.skywalking.oap.meter.analyzer.v2.prometheus.rule.Rule;
+import org.apache.skywalking.oap.meter.analyzer.v2.prometheus.rule.Rules;
+import org.apache.skywalking.oap.server.library.module.ModuleConfig;
+import org.apache.skywalking.oap.server.library.module.ModuleStartException;
+
+import static java.util.Objects.nonNull;
+
+/**
+ * GraalVM replacement for upstream LogAnalyzerModuleConfig.
+ * Change: Added @Setter at class level so config-generator can set all fields via Lombok setters.
+ * Why: Upstream only has @Setter on specific fields. The meterConfigs field is lazy-loaded and
+ * won't be set from config, but having the setter avoids compile errors in generated YamlConfigLoaderUtils.
+ */
+@EqualsAndHashCode(callSuper = false)
+@Getter
+@Setter
+public class LogAnalyzerModuleConfig extends ModuleConfig {
+    private String lalPath = "lal";
+
+    private String malPath = "log-mal-rules";
+
+    private String lalFiles = "default.yaml";
+
+    private String malFiles;
+
+    private List<Rule> meterConfigs;
+
+    public List<String> lalFiles() {
+        return Splitter.on(",").omitEmptyStrings().trimResults().splitToList(Strings.nullToEmpty(getLalFiles()));
+    }
+
+    public List<Rule> malConfigs() throws ModuleStartException {
+        if (nonNull(meterConfigs)) {
+            return meterConfigs;
+        }
+        final List<String> files = Splitter.on(",")
+                                           .omitEmptyStrings()
+                                           .splitToList(Strings.nullToEmpty(getMalFiles()));
+        try {
+            meterConfigs = Rules.loadRules(getMalPath(), files);
+        } catch (IOException e) {
+            throw new ModuleStartException("Failed to load MAL rules", e);
+        }
+
+        return meterConfigs;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,11 @@
                 <artifactId>event-analyzer</artifactId>
                 <version>${skywalking.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.skywalking</groupId>
+                <artifactId>gen-ai-analyzer</artifactId>
+                <version>${skywalking.version}</version>
+            </dependency>
 
             <!-- Receivers -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <maven.compiler.release>25</maven.compiler.release>
         <!-- Injected by Makefile from skywalking submodule's <revision> property.
              Do not hardcode — always build via `make`. -->
-        <skywalking.version>10.4.0-SNAPSHOT</skywalking.version>
+        <skywalking.version>10.4.0</skywalking.version>
         <graalvm.version>25.0.0</graalvm.version>
         <graalvm.buildtools.version>0.10.4</graalvm.buildtools.version>
         <lombok.version>1.18.40</lombok.version>

--- a/test/doc-scripts/verify-version-mapping.sh
+++ b/test/doc-scripts/verify-version-mapping.sh
@@ -34,21 +34,37 @@ fi
 
 errors=0
 
-# Resolve upstream version string for a submodule commit.
-# If the commit has an upstream tag (vX.Y.Z), return that version.
-# Otherwise, return "{short-commit}-SNAPSHOT".
-resolve_upstream_version() {
+# Resolve acceptable upstream version strings for a submodule commit.
+# Returns both the tag-based version (if available) and the commit-based format,
+# separated by newline. The doc may use either format.
+resolve_upstream_versions() {
     local commit="$1"
     local short
     short=$(echo "$commit" | cut -c1-12)
     local tag
-    tag=$(cd "$REPO_ROOT/skywalking" && git tag --points-at "$commit" 2>/dev/null | grep "^v" | head -1)
+    tag=$(cd "$REPO_ROOT/skywalking" && git tag --points-at "$commit" 2>/dev/null | grep "^v" | head -1) || true
     if [ -n "$tag" ]; then
-        # Strip leading 'v' from tag
         echo "${tag#v}"
-    else
-        echo "\`${short}\`-SNAPSHOT"
     fi
+    echo "\`${short}\`-SNAPSHOT"
+}
+
+# Check if a doc value matches any of the acceptable versions.
+matches_any_version() {
+    local doc_value="$1"
+    local commit="$2"
+    local version
+    while IFS= read -r version; do
+        if [ "$doc_value" = "$version" ]; then
+            return 0
+        fi
+    done < <(resolve_upstream_versions "$commit")
+    return 1
+}
+
+# Return the first (preferred) version string for display.
+resolve_upstream_version() {
+    resolve_upstream_versions "$1" | head -1
 }
 
 # Parse table rows between DOC-CHECK markers.
@@ -78,13 +94,13 @@ while IFS= read -r line; do
     if echo "$distro_ver" | grep -q "(dev)"; then
         # Dev row: verify against current submodule commit
         actual_commit=$(git -C "$REPO_ROOT" ls-tree HEAD skywalking | awk '{print $3}')
-        expected=$(resolve_upstream_version "$actual_commit")
 
-        if [ "$doc_upstream" != "$expected" ]; then
+        if matches_any_version "$doc_upstream" "$actual_commit"; then
+            echo "OK [dev]: $distro_ver -> $doc_upstream"
+        else
+            expected=$(resolve_upstream_version "$actual_commit")
             echo "MISMATCH [dev]: doc says '$doc_upstream' but submodule is at '$expected'"
             errors=$((errors + 1))
-        else
-            echo "OK [dev]: $distro_ver -> $doc_upstream"
         fi
     else
         # Released version: verify against git tag
@@ -100,12 +116,12 @@ while IFS= read -r line; do
             continue
         fi
 
-        expected=$(resolve_upstream_version "$actual_commit")
-        if [ "$doc_upstream" != "$expected" ]; then
+        if matches_any_version "$doc_upstream" "$actual_commit"; then
+            echo "OK [$distro_ver]: $tag -> $doc_upstream"
+        else
+            expected=$(resolve_upstream_version "$actual_commit")
             echo "MISMATCH [$distro_ver]: doc says '$doc_upstream' but tag $tag has '$expected'"
             errors=$((errors + 1))
-        else
-            echo "OK [$distro_ver]: $tag -> $doc_upstream"
         fi
     fi
 done < "$DOC"

--- a/test/doc-scripts/verify-version-mapping.sh
+++ b/test/doc-scripts/verify-version-mapping.sh
@@ -34,6 +34,9 @@ fi
 
 errors=0
 
+# Ensure submodule tags are available (CI shallow clones may not have them).
+(cd "$REPO_ROOT/skywalking" && git fetch --tags --quiet 2>/dev/null) || true
+
 # Resolve acceptable upstream version strings for a submodule commit.
 # Returns both the tag-based version (if available) and the commit-based format,
 # separated by newline. The doc may use either format.

--- a/test/e2e/cases/envoy-ai-gateway/docker-compose.yml
+++ b/test/e2e/cases/envoy-ai-gateway/docker-compose.yml
@@ -49,8 +49,6 @@ services:
       - e2e
     expose:
       - 11434
-    ports:
-      - "11434:11434"
     healthcheck:
       test: ["CMD", "ollama", "list"]
       interval: 5s

--- a/test/e2e/cases/envoy-ai-gateway/docker-compose.yml
+++ b/test/e2e/cases/envoy-ai-gateway/docker-compose.yml
@@ -49,6 +49,8 @@ services:
       - e2e
     expose:
       - 11434
+    ports:
+      - 11434
     healthcheck:
       test: ["CMD", "ollama", "list"]
       interval: 5s

--- a/test/e2e/cases/envoy-ai-gateway/docker-compose.yml
+++ b/test/e2e/cases/envoy-ai-gateway/docker-compose.yml
@@ -1,0 +1,87 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+services:
+  banyandb:
+    extends:
+      file: ../../../../skywalking/test/e2e-v2/script/docker-compose/base-compose.yml
+      service: banyandb
+    networks:
+      - e2e
+
+  oap:
+    image: skywalking-oap-native:latest
+    expose:
+      - 11800
+      - 12800
+    networks:
+      - e2e
+    ports:
+      - 12800
+    environment:
+      SW_HEALTH_CHECKER: default
+      SW_STORAGE_BANYANDB_TARGETS: banyandb:17912
+      SW_CONFIGURATION: none
+    depends_on:
+      banyandb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "nc -nz 127.0.0.1 11800 || exit 1"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  ollama:
+    image: ollama/ollama:0.6.2
+    networks:
+      - e2e
+    expose:
+      - 11434
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  aigw:
+    image: envoyproxy/ai-gateway-cli:latest
+    command: run --run-id=0
+    environment:
+      OPENAI_API_KEY: "dummy-key-not-used"
+      OPENAI_BASE_URL: "http://ollama:11434/v1"
+      OTEL_SERVICE_NAME: e2e-ai-gateway
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://oap:11800
+      OTEL_EXPORTER_OTLP_PROTOCOL: grpc
+      OTEL_METRICS_EXPORTER: otlp
+      OTEL_LOGS_EXPORTER: otlp
+      OTEL_METRIC_EXPORT_INTERVAL: "5000"
+      OTEL_RESOURCE_ATTRIBUTES: "job_name=envoy-ai-gateway,service.instance.id=aigw-1,service.layer=ENVOY_AI_GATEWAY"
+    ports:
+      - 1975
+    networks:
+      - e2e
+    healthcheck:
+      test: ["CMD", "aigw", "healthcheck"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+    depends_on:
+      oap:
+        condition: service_healthy
+      ollama:
+        condition: service_healthy
+
+networks:
+  e2e:

--- a/test/e2e/cases/envoy-ai-gateway/docker-compose.yml
+++ b/test/e2e/cases/envoy-ai-gateway/docker-compose.yml
@@ -50,7 +50,7 @@ services:
     expose:
       - 11434
     ports:
-      - 11434
+      - "11434:11434"
     healthcheck:
       test: ["CMD", "ollama", "list"]
       interval: 5s

--- a/test/e2e/cases/envoy-ai-gateway/e2e.yaml
+++ b/test/e2e/cases/envoy-ai-gateway/e2e.yaml
@@ -29,7 +29,8 @@ setup:
     - name: install swctl
       command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh swctl
     - name: Pull Ollama model
-      command: docker compose -f test/e2e/cases/envoy-ai-gateway/docker-compose.yml exec ollama ollama pull qwen2.5:0.5b
+      command: |
+        curl -s http://${ollama_host}:${ollama_11434}/api/pull -d '{"name":"qwen2.5:0.5b"}' --max-time 300
     - name: Send error requests for log sampling verification
       command: |
         for i in 1 2 3; do

--- a/test/e2e/cases/envoy-ai-gateway/e2e.yaml
+++ b/test/e2e/cases/envoy-ai-gateway/e2e.yaml
@@ -15,11 +15,15 @@
 
 # Envoy AI Gateway E2E — native OAP with BanyanDB
 # Validates ENVOY_AI_GATEWAY layer metrics and logs via OTLP from ai-gateway-cli.
+#
+# NOTE: This test requires downloading a ~400MB Ollama model at runtime.
+# Not suitable for CI (upstream also doesn't run this in CI).
+# Run manually with: e2e run -c test/e2e/cases/envoy-ai-gateway/e2e.yaml
 
 setup:
   env: compose
   file: docker-compose.yml
-  timeout: 20m
+  timeout: 25m
   init-system-environment: ../../script/env
   steps:
     - name: set PATH
@@ -29,8 +33,7 @@ setup:
     - name: install swctl
       command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh swctl
     - name: Pull Ollama model
-      command: |
-        curl -sS http://localhost:11434/api/pull -d '{"name":"qwen2.5:0.5b"}' --max-time 600 -o /dev/null
+      command: docker compose -f test/e2e/cases/envoy-ai-gateway/docker-compose.yml exec ollama ollama pull qwen2.5:0.5b
     - name: Send error requests for log sampling verification
       command: |
         for i in 1 2 3; do

--- a/test/e2e/cases/envoy-ai-gateway/e2e.yaml
+++ b/test/e2e/cases/envoy-ai-gateway/e2e.yaml
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Envoy AI Gateway E2E — native OAP with BanyanDB
+# Validates ENVOY_AI_GATEWAY layer metrics and logs via OTLP from ai-gateway-cli.
+
+setup:
+  env: compose
+  file: docker-compose.yml
+  timeout: 20m
+  init-system-environment: ../../script/env
+  steps:
+    - name: set PATH
+      command: export PATH=/tmp/skywalking-infra-e2e/bin:$PATH
+    - name: install yq
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh yq
+    - name: install swctl
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh swctl
+    - name: Pull Ollama model
+      command: docker compose -f test/e2e/cases/envoy-ai-gateway/docker-compose.yml exec ollama ollama pull qwen2.5:0.5b
+    - name: Send error requests for log sampling verification
+      command: |
+        for i in 1 2 3; do
+          curl -s --max-time 15 -o /dev/null -w "%{http_code} " \
+            http://${aigw_host}:${aigw_1975}/v1/chat/completions \
+            -H 'Content-Type: application/json' \
+            -d '{"model":"nonexistent-model","messages":[{"role":"user","content":"Hi"}]}'
+          sleep 1
+        done
+
+trigger:
+  action: http
+  interval: 3s
+  times: 10
+  url: http://${aigw_host}:${aigw_1975}/v1/chat/completions
+  method: POST
+  headers:
+    Content-Type: application/json
+  body: '{"model":"qwen2.5:0.5b","stream":true,"messages":[{"role":"user","content":"Say hi"}]}'
+
+verify:
+  retry:
+    count: 30
+    interval: 10s
+  cases:
+    - includes:
+        - ../../../../skywalking/test/e2e-v2/cases/envoy-ai-gateway/envoy-ai-gateway-cases.yaml
+
+cleanup:
+  on: always

--- a/test/e2e/cases/envoy-ai-gateway/e2e.yaml
+++ b/test/e2e/cases/envoy-ai-gateway/e2e.yaml
@@ -30,7 +30,7 @@ setup:
       command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh swctl
     - name: Pull Ollama model
       command: |
-        curl -s http://${ollama_host}:${ollama_11434}/api/pull -d '{"name":"qwen2.5:0.5b"}' --max-time 300
+        curl -s http://localhost:11434/api/pull -d '{"name":"qwen2.5:0.5b"}' --max-time 300
     - name: Send error requests for log sampling verification
       command: |
         for i in 1 2 3; do

--- a/test/e2e/cases/envoy-ai-gateway/e2e.yaml
+++ b/test/e2e/cases/envoy-ai-gateway/e2e.yaml
@@ -30,7 +30,7 @@ setup:
       command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh swctl
     - name: Pull Ollama model
       command: |
-        curl -s http://localhost:11434/api/pull -d '{"name":"qwen2.5:0.5b"}' --max-time 300
+        curl -sS http://localhost:11434/api/pull -d '{"name":"qwen2.5:0.5b"}' --max-time 600 -o /dev/null
     - name: Send error requests for log sampling verification
       command: |
         for i in 1 2 3; do

--- a/test/e2e/cases/traceql-skywalking/docker-compose.yml
+++ b/test/e2e/cases/traceql-skywalking/docker-compose.yml
@@ -1,0 +1,132 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+services:
+  banyandb:
+    extends:
+      file: ../../../../skywalking/test/e2e-v2/script/docker-compose/base-compose.yml
+      service: banyandb
+    ports:
+      - 17912
+
+  oap:
+    image: skywalking-oap-native:latest
+    expose:
+      - 11800
+      - 12800
+      - 3200
+    networks:
+      - e2e
+    ports:
+      - 12800
+      - 3200
+    environment:
+      SW_HEALTH_CHECKER: default
+      SW_STORAGE_BANYANDB_TARGETS: banyandb:17912
+      SW_CONFIGURATION: none
+      SW_TRACEQL: default
+      SW_TRACEQL_ENABLE_DATASOURCE_ZIPKIN: "false"
+      SW_TRACEQL_ENABLE_DATASOURCE_SKYWALKING: "true"
+    depends_on:
+      banyandb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "nc -nz 127.0.0.1 11800 || exit 1"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  provider-jar:
+    image: "ghcr.io/apache/skywalking/e2e-service-provider:${SW_E2E_SERVICE_COMMIT}"
+    entrypoint: ["cp", "/app.jar", "/jars/services_provider.jar"]
+    volumes:
+      - service-jars:/jars
+    networks:
+      - e2e
+
+  consumer-jar:
+    image: "ghcr.io/apache/skywalking/e2e-service-consumer:${SW_E2E_SERVICE_COMMIT}"
+    entrypoint: ["cp", "/app.jar", "/jars/services_consumer.jar"]
+    volumes:
+      - service-jars:/jars
+    networks:
+      - e2e
+
+  provider:
+    image: "ghcr.io/apache/skywalking-java/skywalking-java:${SW_AGENT_JAVA_COMMIT}-java${SW_AGENT_JDK_VERSION}"
+    command: ["java", "-jar", "/jars/services_provider.jar"]
+    volumes:
+      - service-jars:/jars
+    networks:
+      - e2e
+    expose:
+      - 9090
+    ports:
+      - 9090
+    environment:
+      SW_AGENT_COLLECTOR_BACKEND_SERVICES: oap:11800
+      SW_LOGGING_OUTPUT: CONSOLE
+      SW_AGENT_NAME: e2e-service-provider
+      SW_AGENT_INSTANCE_NAME: provider1
+      SW_AGENT_COLLECTOR_GET_PROFILE_TASK_INTERVAL: 1
+      SW_AGENT_COLLECTOR_GET_AGENT_DYNAMIC_CONFIG_INTERVAL: 1
+      SW_METER_ACTIVE: 'false'
+    healthcheck:
+      test: ["CMD", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/9090"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+    depends_on:
+      oap:
+        condition: service_healthy
+      provider-jar:
+        condition: service_completed_successfully
+
+  consumer:
+    image: "ghcr.io/apache/skywalking-java/skywalking-java:${SW_AGENT_JAVA_COMMIT}-java${SW_AGENT_JDK_VERSION}"
+    command: ["java", "-jar", "/jars/services_consumer.jar"]
+    volumes:
+      - service-jars:/jars
+    networks:
+      - e2e
+    expose:
+      - 9092
+    ports:
+      - 9092
+    environment:
+      SW_AGENT_COLLECTOR_BACKEND_SERVICES: oap:11800
+      SW_LOGGING_OUTPUT: CONSOLE
+      PROVIDER_URL: http://provider:9090
+      SW_AGENT_NAME: e2e-service-consumer
+      SW_AGENT_INSTANCE_NAME: consumer1
+      SW_AGENT_COLLECTOR_GET_PROFILE_TASK_INTERVAL: 1
+      SW_AGENT_COLLECTOR_GET_AGENT_DYNAMIC_CONFIG_INTERVAL: 1
+      SW_METER_ACTIVE: 'false'
+    healthcheck:
+      test: ["CMD", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/9092"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+    depends_on:
+      provider:
+        condition: service_healthy
+      consumer-jar:
+        condition: service_completed_successfully
+
+volumes:
+  service-jars:
+
+networks:
+  e2e:

--- a/test/e2e/cases/traceql-skywalking/e2e.yaml
+++ b/test/e2e/cases/traceql-skywalking/e2e.yaml
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# TraceQL SkyWalking E2E — native OAP with BanyanDB
+# Tests the Tempo-compatible TraceQL query API with SkyWalking native datasource.
+
+setup:
+  env: compose
+  file: docker-compose.yml
+  timeout: 20m
+  init-system-environment: ../../script/env
+  steps:
+    - name: set PATH
+      command: export PATH=/tmp/skywalking-infra-e2e/bin:$PATH
+    - name: install yq
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh yq
+    - name: install swctl
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh swctl
+    - name: install jq
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh jq
+
+trigger:
+  action: http
+  interval: 3s
+  times: -1
+  url: http://${consumer_host}:${consumer_9092}/users
+  method: POST
+  body: '{"id":"123","name":"skywalking"}'
+  headers:
+    "Content-Type": "application/json"
+
+verify:
+  retry:
+    count: 20
+    interval: 10s
+  cases:
+    - includes:
+        - ../../../../skywalking/test/e2e-v2/cases/traceql/skywalking/traceql-cases.yaml

--- a/test/e2e/cases/virtual-genai/docker-compose.yml
+++ b/test/e2e/cases/virtual-genai/docker-compose.yml
@@ -87,7 +87,7 @@ services:
         - SW_AGENT_JDK_VERSION=17
         - SW_AGENT_JAVA_COMMIT=${SW_AGENT_JAVA_COMMIT}
     ports:
-      - 8080
+      - "9260:8080"
     networks:
       - e2e
     environment:

--- a/test/e2e/cases/virtual-genai/docker-compose.yml
+++ b/test/e2e/cases/virtual-genai/docker-compose.yml
@@ -63,7 +63,7 @@ services:
     networks:
       - e2e
     environment:
-      OPENAI_API_KEY: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      OPENAI_API_KEY: dummy-key-not-used
       SPRING_AI_OPENAI_BASE_URL: http://provider:9090/llm
       SW_AGENT_COLLECTOR_BACKEND_SERVICES: oap:11800
       SW_LOGGING_OUTPUT: CONSOLE

--- a/test/e2e/cases/virtual-genai/docker-compose.yml
+++ b/test/e2e/cases/virtual-genai/docker-compose.yml
@@ -1,0 +1,82 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+services:
+  banyandb:
+    extends:
+      file: ../../../../skywalking/test/e2e-v2/script/docker-compose/base-compose.yml
+      service: banyandb
+    ports:
+      - 17912
+
+  oap:
+    image: skywalking-oap-native:latest
+    expose:
+      - 11800
+      - 12800
+    networks:
+      - e2e
+    ports:
+      - 12800
+    environment:
+      SW_HEALTH_CHECKER: default
+      SW_STORAGE_BANYANDB_TARGETS: banyandb:17912
+      SW_CONFIGURATION: none
+    depends_on:
+      banyandb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "nc -nz 127.0.0.1 11800 || exit 1"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  provider:
+    extends:
+      file: ../../../../skywalking/test/e2e-v2/script/docker-compose/base-compose.yml
+      service: provider
+    depends_on:
+      oap:
+        condition: service_healthy
+
+  spring-ai-examples:
+    build:
+      context: ../../../../skywalking/test/e2e-v2/cases/virtual-genai
+      dockerfile: Dockerfile.provider
+      args:
+        - SW_AGENT_JDK_VERSION=17
+        - SW_AGENT_JAVA_COMMIT=${SW_AGENT_JAVA_COMMIT}
+    ports:
+      - 8080
+    networks:
+      - e2e
+    environment:
+      OPENAI_API_KEY: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      SPRING_AI_OPENAI_BASE_URL: http://provider:9090/llm
+      SW_AGENT_COLLECTOR_BACKEND_SERVICES: oap:11800
+      SW_LOGGING_OUTPUT: CONSOLE
+      SW_AGENT_NAME: e2e-spring-ai
+      SW_AGENT_INSTANCE_NAME: spring-ai-examples
+    healthcheck:
+      test: ["CMD", "sh", "-c", "nc -nz 127.0.0.1 8080"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+    depends_on:
+      oap:
+        condition: service_healthy
+
+networks:
+  e2e:

--- a/test/e2e/cases/virtual-genai/docker-compose.yml
+++ b/test/e2e/cases/virtual-genai/docker-compose.yml
@@ -79,7 +79,7 @@ services:
       provider-jar:
         condition: service_completed_successfully
 
-  spring-ai-examples:
+  spring_ai:
     build:
       context: ../../../../skywalking/test/e2e-v2/cases/virtual-genai
       dockerfile: Dockerfile.provider
@@ -87,7 +87,7 @@ services:
         - SW_AGENT_JDK_VERSION=17
         - SW_AGENT_JAVA_COMMIT=${SW_AGENT_JAVA_COMMIT}
     ports:
-      - "9260:8080"
+      - 8080
     networks:
       - e2e
     environment:
@@ -96,7 +96,7 @@ services:
       SW_AGENT_COLLECTOR_BACKEND_SERVICES: oap:11800
       SW_LOGGING_OUTPUT: CONSOLE
       SW_AGENT_NAME: e2e-spring-ai
-      SW_AGENT_INSTANCE_NAME: spring-ai-examples
+      SW_AGENT_INSTANCE_NAME: spring_ai
     healthcheck:
       test: ["CMD", "sh", "-c", "nc -nz 127.0.0.1 8080"]
       interval: 5s

--- a/test/e2e/cases/virtual-genai/docker-compose.yml
+++ b/test/e2e/cases/virtual-genai/docker-compose.yml
@@ -43,13 +43,41 @@ services:
       timeout: 60s
       retries: 120
 
+  provider-jar:
+    image: "ghcr.io/apache/skywalking/e2e-service-provider:${SW_E2E_SERVICE_COMMIT}"
+    entrypoint: ["cp", "/app.jar", "/jars/services_provider.jar"]
+    volumes:
+      - service-jars:/jars
+    networks:
+      - e2e
+
   provider:
-    extends:
-      file: ../../../../skywalking/test/e2e-v2/script/docker-compose/base-compose.yml
-      service: provider
+    image: "ghcr.io/apache/skywalking-java/skywalking-java:${SW_AGENT_JAVA_COMMIT}-java${SW_AGENT_JDK_VERSION}"
+    command: ["java", "-jar", "/jars/services_provider.jar"]
+    volumes:
+      - service-jars:/jars
+    networks:
+      - e2e
+    expose:
+      - 9090
+    ports:
+      - 9090
+    environment:
+      SW_AGENT_COLLECTOR_BACKEND_SERVICES: oap:11800
+      SW_LOGGING_OUTPUT: CONSOLE
+      SW_AGENT_NAME: e2e-service-provider
+      SW_AGENT_INSTANCE_NAME: provider1
+      SW_METER_ACTIVE: 'false'
+    healthcheck:
+      test: ["CMD", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/9090"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
     depends_on:
       oap:
         condition: service_healthy
+      provider-jar:
+        condition: service_completed_successfully
 
   spring-ai-examples:
     build:
@@ -77,6 +105,9 @@ services:
     depends_on:
       oap:
         condition: service_healthy
+
+volumes:
+  service-jars:
 
 networks:
   e2e:

--- a/test/e2e/cases/virtual-genai/docker-compose.yml
+++ b/test/e2e/cases/virtual-genai/docker-compose.yml
@@ -79,7 +79,7 @@ services:
       provider-jar:
         condition: service_completed_successfully
 
-  spring_ai:
+  spring-ai-examples:
     build:
       context: ../../../../skywalking/test/e2e-v2/cases/virtual-genai
       dockerfile: Dockerfile.provider
@@ -96,7 +96,7 @@ services:
       SW_AGENT_COLLECTOR_BACKEND_SERVICES: oap:11800
       SW_LOGGING_OUTPUT: CONSOLE
       SW_AGENT_NAME: e2e-spring-ai
-      SW_AGENT_INSTANCE_NAME: spring_ai
+      SW_AGENT_INSTANCE_NAME: spring-ai-examples
     healthcheck:
       test: ["CMD", "sh", "-c", "nc -nz 127.0.0.1 8080"]
       interval: 5s

--- a/test/e2e/cases/virtual-genai/e2e.yaml
+++ b/test/e2e/cases/virtual-genai/e2e.yaml
@@ -33,7 +33,7 @@ trigger:
   action: http
   interval: 3s
   times: 5
-  url: http://${spring_ai_host}:${spring_ai_8080}/ai/generateStream
+  url: http://localhost:9260/ai/generateStream
   method: GET
 
 verify:

--- a/test/e2e/cases/virtual-genai/e2e.yaml
+++ b/test/e2e/cases/virtual-genai/e2e.yaml
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Virtual GenAI E2E — native OAP with BanyanDB
+# Validates GenAI provider/model metrics from Spring AI + SkyWalking Java agent.
+
+setup:
+  env: compose
+  file: docker-compose.yml
+  timeout: 20m
+  init-system-environment: ../../script/env
+  steps:
+    - name: set PATH
+      command: export PATH=/tmp/skywalking-infra-e2e/bin:$PATH
+    - name: install yq
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh yq
+    - name: install swctl
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh swctl
+
+trigger:
+  action: http
+  interval: 3s
+  times: 5
+  url: http://${spring_ai_host}:${spring_ai_8080}/ai/generateStream
+  method: GET
+
+verify:
+  retry:
+    count: 60
+    interval: 3s
+  cases:
+    - includes:
+        - ../../../../skywalking/test/e2e-v2/cases/virtual-genai/virtual-genai.yaml

--- a/test/e2e/cases/virtual-genai/e2e.yaml
+++ b/test/e2e/cases/virtual-genai/e2e.yaml
@@ -33,7 +33,7 @@ trigger:
   action: http
   interval: 3s
   times: 5
-  url: http://localhost:9260/ai/generateStream
+  url: http://${spring_ai_host}:${spring_ai_8080}/ai/generateStream
   method: GET
 
 verify:

--- a/test/e2e/cases/virtual-genai/e2e.yaml
+++ b/test/e2e/cases/virtual-genai/e2e.yaml
@@ -33,7 +33,7 @@ trigger:
   action: http
   interval: 3s
   times: 5
-  url: http://${spring_ai_host}:${spring_ai_8080}/ai/generateStream
+  url: http://${spring_ai_examples_host}:${spring_ai_examples_8080}/ai/generateStream
   method: GET
 
 verify:

--- a/test/e2e/cases/virtual-genai/e2e.yaml
+++ b/test/e2e/cases/virtual-genai/e2e.yaml
@@ -33,7 +33,7 @@ trigger:
   action: http
   interval: 3s
   times: 5
-  url: http://${spring_ai_examples_host}:${spring_ai_examples_8080}/ai/generateStream
+  url: http://localhost:9260/ai/generateStream
   method: GET
 
 verify:

--- a/test/e2e/script/env
+++ b/test/e2e/script/env
@@ -15,16 +15,16 @@
 
 # Pre-built images from ghcr.io/apache/skywalking and ghcr.io/apache/skywalking-java.
 # Update when syncing the skywalking submodule.
-SW_AGENT_JAVA_COMMIT=2a61027e5eb74ed1258c764ae2ffeabd499416a6
-SW_BANYANDB_COMMIT=e1ba421bd624727760c7a69c84c6fe55878fb526
+SW_AGENT_JAVA_COMMIT=ac0df43d7140e726eba9e5e5b1b75cf364c71dff
+SW_BANYANDB_COMMIT=d0f41f9ad139c917c1398c2e62a9f7034214495f
 SW_CTL_COMMIT=9a1beab08413ce415a00a8547a238a14691c5655
 SW_KUBERNETES_COMMIT_SHA=6fe5e6f0d3b7686c6be0457733e825ee68cb9b35
 
 # Skywalking submodule commit — used for pre-built images (ui, e2e-service, etc.)
-SW_UPSTREAM_COMMIT=a0cec0ca237792497d2da0b65757d11f58c3f342
+SW_UPSTREAM_COMMIT=b272da3cc196c2455bf86e911c427d302f68b950
 
 # Last upstream commit that touched test/e2e-v2/java-test-service/
-SW_E2E_SERVICE_COMMIT=5e3b3853f5742f906655f3e332459c74b58cfb43
+SW_E2E_SERVICE_COMMIT=f79451d3de23edb15277f5b6e315dc6779e73e1f
 
 # OTEL collector version for infrastructure monitoring tests
 OTEL_COLLECTOR_VERSION=0.102.1

--- a/test/e2e/script/env
+++ b/test/e2e/script/env
@@ -20,8 +20,9 @@ SW_BANYANDB_COMMIT=d0f41f9ad139c917c1398c2e62a9f7034214495f
 SW_CTL_COMMIT=9a1beab08413ce415a00a8547a238a14691c5655
 SW_KUBERNETES_COMMIT_SHA=6fe5e6f0d3b7686c6be0457733e825ee68cb9b35
 
-# Skywalking submodule commit — used for pre-built images (ui, e2e-service, etc.)
-SW_UPSTREAM_COMMIT=b272da3cc196c2455bf86e911c427d302f68b950
+# Last upstream commit with ghcr.io images published (commit before release prep).
+# Release tags publish to Docker Hub, not ghcr.io, so we use the prior CI commit.
+SW_UPSTREAM_COMMIT=f79451d3de23edb15277f5b6e315dc6779e73e1f
 
 # Last upstream commit that touched test/e2e-v2/java-test-service/
 SW_E2E_SERVICE_COMMIT=f79451d3de23edb15277f5b6e315dc6779e73e1f


### PR DESCRIPTION
### Sync upstream SkyWalking submodule to v10.4.0 release

#### Upstream Sync
- Update `skywalking/` submodule from `726ebcc321` to `v10.4.0` tag (`b272da3cc1`)
- 19 upstream commits covering GenAI monitoring, Envoy AI Gateway, TraceQL SkyWalking native traces, MAL compiler refactor

#### New Module: gen-ai-analyzer
- Wire `GenAIAnalyzerModule` + `GenAIAnalyzerModuleProvider` in `GraalVMOAPServerStartUp`
- Add `gen-ai-analyzer` to `AcceptedModules`, `application.yml`, `distro-policy.md`
- Regenerate `YamlConfigLoaderUtils` with `GenAIConfig` / `GenAIConfig$Provider` / `GenAIConfig$Model`
- Add `gen-ai-config.yml` to both distribution assemblies
- Add 22 GenAI OAL metrics + 22 builder classes to `reachability-metadata.json`

#### Envoy AI Gateway
- Add `envoy-ai-gateway` to LAL files and OTEL metrics rules in `application.yml`
- Add 34 MAL comparison tests for gateway-service and gateway-instance rules

#### TraceQL
- Add `lookback`, `zipkinTracesListResultTags`, `skywalkingTracesListResultTags` config properties

#### Config Generator Fix
- Skip imports for config classes with no fields (avoids checkstyle unused import errors)
- `LogAnalyzerModuleConfig`: create same-FQCN replacement with `@Setter` (upstream `meterConfigs` field lacks setter)

#### E2E Tests
- Add `virtual-genai` e2e test case (GenAI metrics via Spring AI + Java agent)
- Add `envoy-ai-gateway` e2e test case (ENVOY_AI_GATEWAY layer via OTLP + Ollama)
- Add `traceql-skywalking` e2e test case (Tempo API with SkyWalking native trace datasource)
- Update e2e image commits (`SW_UPSTREAM_COMMIT`, `SW_E2E_SERVICE_COMMIT`, `SW_BANYANDB_COMMIT`, `SW_AGENT_JAVA_COMMIT`)

#### Other
- Add `sync-submodule` skill with full checklist for future submodule updates

- [x] Tests pass: `make test` (1328 tests, 0 failures)
- [x] License headers valid: `license-eye header check` (0 invalid)
- [x] `changes/changes.md` updated