### PR TITLE
Add live-debugging e2e + fix native-image 404 on the unsupported-admin stub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,6 +380,8 @@ jobs:
           #   case: envoy-ai-gateway
           - name: TraceQL SkyWalking
             case: traceql-skywalking
+          - name: Live Debugging
+            case: live-debugging
     steps:
       - name: Checkout with submodules
         uses: actions/checkout@v5

--- a/changes/changes.md
+++ b/changes/changes.md
@@ -16,6 +16,7 @@
 - Port the new upstream runtime-rule DSL overloads into the same-FQCN replacements: meter `DSL.parse(..., ClassPool, ClassLoader)`, `FilterExpression(..., ClassPool, ClassLoader)`, and log `DSL.of(..., ClassPool, ClassLoader)`.
 - The precompiler and the MAL comparison tests now compose expressions via the real upstream `MetricConvert.formatExp` (ANTLR `injectExpPrefix`) instead of a hand-rolled replica, fixing pre-compiled class lookup for chained expressions (`.sum` / `.rate` / `.downsampling`).
 - Register protobuf descriptor **editions** classes (`com.google.protobuf.DescriptorProtos$*`, incl. `FeatureSet`) and **protoc-gen-validate** classes (`io.envoyproxy.pgv.validate.Validate$*`) for native-image reflection. protobuf-java 4.33 (pulled by the sync) reflects on these when parsing the BanyanDB measure descriptors (editions features + field-validation options); without the metadata, BanyanDB metrics queries failed at runtime with `Generated message class ... missing method` (e.g. `FeatureSet.getFieldPresence`).
+- Register `UnsupportedAdminFeatureHandler` for native-image reflection in `reachability-metadata.json`. Armeria builds its annotated routes by reflection, but this distro-only 501 stub is not on the build-time precompiler's classpath (it depends on the precompiler output), so its routes were never registered — the DSL live debugger (`/dsl-debugging/*`) and runtime-rule (`/runtime/*`) prefixes returned 404 instead of the intended 501. Caught by the new `live-debugging` e2e.
 
 ### Documentation
 
@@ -30,6 +31,7 @@
 - Bump pinned dependency images for the 11.0.0 sync: BanyanDB `84b919e`, Kubernetes `da0e267`, e2e java-test-service `7754e3e`.
 - Bump `skywalking-infra-e2e` to upstream's pin (`0d917694`) — the synced e2e expected-output templates use the `containsOnce` verify function, which the prior pin predated.
 - Remove the `menu` e2e case (CI matrix + wrapper): upstream dropped the bundled UI in 11.0.0 (#13877), deleting `test/e2e-v2/cases/menu/`, so the distro wrapper referenced a non-existent reuse file.
+- Add the `live-debugging` e2e case: boots the native OAP and asserts the admin-server (`:17128`) returns the structured HTTP 501 for the DSL live debugger (`/dsl-debugging/*`) and runtime-rule (`/runtime/*`) endpoints. The first e2e to exercise the admin port — it caught the missing reflection registration noted above (the stub had been returning 404).
 
 ## 0.3.0
 

--- a/oap-graalvm-native/src/main/resources/META-INF/native-image/org.apache.skywalking/oap-graalvm-native/reachability-metadata.json
+++ b/oap-graalvm-native/src/main/resources/META-INF/native-image/org.apache.skywalking/oap-graalvm-native/reachability-metadata.json
@@ -1,5 +1,6 @@
 {
   "reflection": [
+    { "type": "org.apache.skywalking.oap.server.graalvm.admin.UnsupportedAdminFeatureHandler", "allDeclaredFields": true, "allDeclaredMethods": true, "allDeclaredConstructors": true },
     { "type": "io.envoyproxy.pgv.validate.Validate$AnyRules", "allDeclaredFields": true, "allDeclaredMethods": true, "allDeclaredConstructors": true },
     { "type": "io.envoyproxy.pgv.validate.Validate$AnyRules$Builder", "allDeclaredFields": true, "allDeclaredMethods": true, "allDeclaredConstructors": true },
     { "type": "io.envoyproxy.pgv.validate.Validate$BoolRules", "allDeclaredFields": true, "allDeclaredMethods": true, "allDeclaredConstructors": true },

--- a/oap-graalvm-server/src/main/java/org/apache/skywalking/oap/server/graalvm/admin/UnsupportedAdminFeatureHandler.java
+++ b/oap-graalvm-server/src/main/java/org/apache/skywalking/oap/server/graalvm/admin/UnsupportedAdminFeatureHandler.java
@@ -38,6 +38,12 @@ import com.linecorp.armeria.server.annotation.Put;
  * <p>Routes are registered with Armeria {@code prefix:} patterns so every verb and sub-path
  * under the two roots resolves here, returning a structured payload the Horizon UI can render
  * instead of hitting a connection error.
+ *
+ * <p>This distro-only class is not on the build-time precompiler's classpath (it depends on the
+ * precompiler output), so the precompiler's Armeria-handler scan cannot register it. Its
+ * reflection metadata is maintained by hand in {@code oap-graalvm-native}'s
+ * {@code reachability-metadata.json}; without it Armeria silently builds zero routes and these
+ * prefixes return 404 instead of 501.
  */
 public class UnsupportedAdminFeatureHandler {
 

--- a/test/e2e/cases/live-debugging/docker-compose.yml
+++ b/test/e2e/cases/live-debugging/docker-compose.yml
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+services:
+  banyandb:
+    extends:
+      file: ../../../../skywalking/test/e2e-v2/script/docker-compose/base-compose.yml
+      service: banyandb
+    ports:
+      - 17912
+
+  oap:
+    image: skywalking-oap-native:latest
+    expose:
+      - 11800
+      - 12800
+      - 17128
+    networks:
+      - e2e
+    ports:
+      - 17128
+    environment:
+      SW_HEALTH_CHECKER: default
+      SW_STORAGE_BANYANDB_TARGETS: banyandb:17912
+      SW_CONFIGURATION: none
+    depends_on:
+      banyandb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "nc -nz 127.0.0.1 11800 || exit 1"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+networks:
+  e2e:

--- a/test/e2e/cases/live-debugging/e2e.yaml
+++ b/test/e2e/cases/live-debugging/e2e.yaml
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Live Debugging E2E — native OAP with BanyanDB.
+# The SWIP-13 DSL live debugger (/dsl-debugging/*) and runtime-rule hot-update (/runtime/*)
+# generate fresh MAL/LAL/OAL bytecode with Javassist at runtime, which a closed-world native
+# image cannot do. This distro pre-compiles all DSL at build time and serves a structured
+# HTTP 501 for those admin-server endpoints. This case verifies that contract.
+# Verify-only (no trigger): infra-e2e's trigger step aborts on a non-2xx response, so the
+# 501 is asserted through verify cases that curl the admin-server (port 17128) directly.
+
+setup:
+  env: compose
+  file: docker-compose.yml
+  timeout: 20m
+  init-system-environment: ../../script/env
+  steps:
+    - name: set PATH
+      command: export PATH=/tmp/skywalking-infra-e2e/bin:$PATH
+
+verify:
+  retry:
+    count: 60
+    interval: 3s
+  cases:
+    - includes:
+        - live-debugging-cases.yaml

--- a/test/e2e/cases/live-debugging/expected/dsl-debugging-session.yml
+++ b/test/e2e/cases/live-debugging/expected/dsl-debugging-session.yml
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+status: 501
+error: feature_not_available_in_graalvm_native
+feature: dsl-debugging
+path: /dsl-debugging/session
+message: "This feature requires runtime DSL (MAL/LAL/OAL) compilation, which is not available in the SkyWalking GraalVM native distribution. All DSL rules are pre-compiled at build time; runtime rule hot-update and the DSL live debugger are disabled. Use the standard JVM OAP distribution if you need these features."

--- a/test/e2e/cases/live-debugging/expected/dsl-debugging-sessions.yml
+++ b/test/e2e/cases/live-debugging/expected/dsl-debugging-sessions.yml
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+status: 501
+error: feature_not_available_in_graalvm_native
+feature: dsl-debugging
+path: /dsl-debugging/sessions
+message: "This feature requires runtime DSL (MAL/LAL/OAL) compilation, which is not available in the SkyWalking GraalVM native distribution. All DSL rules are pre-compiled at build time; runtime rule hot-update and the DSL live debugger are disabled. Use the standard JVM OAP distribution if you need these features."

--- a/test/e2e/cases/live-debugging/expected/dsl-debugging-status.yml
+++ b/test/e2e/cases/live-debugging/expected/dsl-debugging-status.yml
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+status: 501
+error: feature_not_available_in_graalvm_native
+feature: dsl-debugging
+path: /dsl-debugging/status
+message: "This feature requires runtime DSL (MAL/LAL/OAL) compilation, which is not available in the SkyWalking GraalVM native distribution. All DSL rules are pre-compiled at build time; runtime rule hot-update and the DSL live debugger are disabled. Use the standard JVM OAP distribution if you need these features."

--- a/test/e2e/cases/live-debugging/expected/http-status-501.yml
+++ b/test/e2e/cases/live-debugging/expected/http-status-501.yml
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+httpStatus: 501

--- a/test/e2e/cases/live-debugging/expected/runtime-oal-files.yml
+++ b/test/e2e/cases/live-debugging/expected/runtime-oal-files.yml
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+status: 501
+error: feature_not_available_in_graalvm_native
+feature: runtime-rule
+path: /runtime/oal/files
+message: "This feature requires runtime DSL (MAL/LAL/OAL) compilation, which is not available in the SkyWalking GraalVM native distribution. All DSL rules are pre-compiled at build time; runtime rule hot-update and the DSL live debugger are disabled. Use the standard JVM OAP distribution if you need these features."

--- a/test/e2e/cases/live-debugging/expected/runtime-rule-addorupdate.yml
+++ b/test/e2e/cases/live-debugging/expected/runtime-rule-addorupdate.yml
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+status: 501
+error: feature_not_available_in_graalvm_native
+feature: runtime-rule
+path: /runtime/rule/addOrUpdate
+message: "This feature requires runtime DSL (MAL/LAL/OAL) compilation, which is not available in the SkyWalking GraalVM native distribution. All DSL rules are pre-compiled at build time; runtime rule hot-update and the DSL live debugger are disabled. Use the standard JVM OAP distribution if you need these features."

--- a/test/e2e/cases/live-debugging/expected/runtime-rule-list.yml
+++ b/test/e2e/cases/live-debugging/expected/runtime-rule-list.yml
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+status: 501
+error: feature_not_available_in_graalvm_native
+feature: runtime-rule
+path: /runtime/rule/list
+message: "This feature requires runtime DSL (MAL/LAL/OAL) compilation, which is not available in the SkyWalking GraalVM native distribution. All DSL rules are pre-compiled at build time; runtime rule hot-update and the DSL live debugger are disabled. Use the standard JVM OAP distribution if you need these features."

--- a/test/e2e/cases/live-debugging/live-debugging-cases.yaml
+++ b/test/e2e/cases/live-debugging/live-debugging-cases.yaml
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Asserts the GraalVM native distro returns a structured HTTP 501 for the DSL live debugger
+# (SWIP-13) and runtime-rule hot-update endpoints — both unsupported under a native image.
+# The response body carries status/error/feature/path/message; the message directs users to
+# the standard JVM OAP distribution. The body's `status: 501` is set by the same handler that
+# sets the HTTP 501 status line, which the dedicated httpStatus cases verify independently.
+cases:
+  # --- DSL live debugger (/dsl-debugging/*) -> 501, feature=dsl-debugging ---
+  - query: curl -s http://${oap_host}:${oap_17128}/dsl-debugging/status
+    expected: expected/dsl-debugging-status.yml
+  - query: curl -s -X POST http://${oap_host}:${oap_17128}/dsl-debugging/session
+    expected: expected/dsl-debugging-session.yml
+  - query: curl -s http://${oap_host}:${oap_17128}/dsl-debugging/sessions
+    expected: expected/dsl-debugging-sessions.yml
+
+  # --- runtime-rule hot-update (/runtime/*) -> 501, feature=runtime-rule ---
+  - query: curl -s -X POST http://${oap_host}:${oap_17128}/runtime/rule/addOrUpdate
+    expected: expected/runtime-rule-addorupdate.yml
+  - query: curl -s http://${oap_host}:${oap_17128}/runtime/rule/list
+    expected: expected/runtime-rule-list.yml
+  - query: curl -s http://${oap_host}:${oap_17128}/runtime/oal/files
+    expected: expected/runtime-oal-files.yml
+
+  # --- HTTP status line is exactly 501 (one per feature root) ---
+  # Quoted in YAML because the echoed "httpStatus:" carries a colon-space.
+  - query: "echo httpStatus: $(curl -s -o /dev/null -w '%{http_code}' http://${oap_host}:${oap_17128}/dsl-debugging/status)"
+    expected: expected/http-status-501.yml
+  - query: "echo httpStatus: $(curl -s -o /dev/null -w '%{http_code}' http://${oap_host}:${oap_17128}/runtime/rule/list)"
+    expected: expected/http-status-501.yml


### PR DESCRIPTION
### Add a live-debugging e2e and fix the latent native-image bug it exposed

Immigrates an e2e that verifies the distro's contract for the **DSL live debugger** (SWIP-13, `/dsl-debugging/*`) and **runtime-rule hot-update** (`/runtime/*`). Both need runtime Javassist codegen the closed-world native image can't do, so the admin-server (`:17128`) answers them with a structured **HTTP 501** that points users to the JVM distribution.

**What it caught:** running the case against the native OAP showed those endpoints returning **404, not 501**. `UnsupportedAdminFeatureHandler` is a distro-only Armeria handler, so the build-time precompiler (which `oap-graalvm-server` depends on, hence cannot scan it) never registered its reflection metadata. Armeria builds annotated routes by reflection, so the routes were silently never created. The boot log even prints `Bind handler UnsupportedAdminFeatureHandler into http server 0.0.0.0:17128`, yet every request 404s. It had been dead since written — no prior e2e exercised port 17128. Fixed by registering the handler in `reachability-metadata.json` with the same flags the precompiler emits for upstream admin handlers.

- [x] Adds `test/e2e/cases/live-debugging/` (8 verify cases: 6 response-body assertions across both prefixes and all verbs + 2 HTTP-status-line checks) and the CI matrix entry.
- [x] Fixes the 404 -> 501 regression via the reflection registration.
- [x] Updated `changes/changes.md`.
- [x] Verified locally end-to-end: native rebuild + infra-e2e run = **8/8 pass** (404 before the fix).
- [x] License headers valid: `license-eye header check` (0 invalid).