### PR TITLE
Sync upstream to 89624809f0: adopt swctl admin e2e migration

### DIFF
--- a/changes/changes.md
+++ b/changes/changes.md
@@ -4,7 +4,7 @@
 
 ### Upstream Sync
 
-- Sync SkyWalking submodule to upstream `ad733554b0` (11.0.0-SNAPSHOT).
+- Sync SkyWalking submodule to upstream `89624809f0` (11.0.0-SNAPSHOT).
 - Wire the admin-server family on the admin host (HTTP `:17128`, admin-internal gRPC `:17129`): `admin-server`, `status` (relocated from the 10.x `status-query` plugin — `/status/*`, `/debugging/*`), `inspect` (SWIP-14 metric catalog, `/inspect/*`), and `ui-management` (dashboard-template REST for the Horizon UI, `/ui-management/*`). The `status-query` plugin is removed.
 - Enable iOS (SWIP-11) and mini-program (SWIP-12) OTel metrics rules and Envoy AI Gateway MCP rules; add the mini-program log-MAL rules and the `ai_route_type` searchable log tag.
 - Drop the bundled UI templates: upstream 11.0.0 removed `ui-initialized-templates/` and `UITemplateInitializer`; templates are now managed via `ui-management`.
@@ -20,7 +20,7 @@
 
 ### Documentation
 
-- Document the admin-server family, the status relocation, and the unsupported DSL-debugging / runtime-rule features (HTTP 501) in `distro-policy.md` and `supported-features.md`; add the `0.4.0` → `ad733554b0` row to `version-mapping.md`.
+- Document the admin-server family, the status relocation, and the unsupported DSL-debugging / runtime-rule features (HTTP 501) in `distro-policy.md` and `supported-features.md`; add the `0.4.0` → `89624809f0` row to `version-mapping.md`.
 
 ### Testing
 
@@ -32,6 +32,7 @@
 - Bump `skywalking-infra-e2e` to upstream's pin (`0d917694`) — the synced e2e expected-output templates use the `containsOnce` verify function, which the prior pin predated.
 - Remove the `menu` e2e case (CI matrix + wrapper): upstream dropped the bundled UI in 11.0.0 (#13877), deleting `test/e2e-v2/cases/menu/`, so the distro wrapper referenced a non-existent reuse file.
 - Add the `live-debugging` e2e case: boots the native OAP and asserts the admin-server (`:17128`) returns the structured HTTP 501 for the DSL live debugger (`/dsl-debugging/*`) and runtime-rule (`/runtime/*`) endpoints. The first e2e to exercise the admin port — it caught the missing reflection registration noted above (the stub had been returning 404).
+- Adopt the upstream **swctl admin** migration (#13889): bump the pinned `skywalking-cli` (`SW_CTL_COMMIT`) to the admin-capable commit (`b447211a`) and drive the `live-debugging` admin checks through `swctl admin dsl-debug` / `runtime-rule` / `oal` alongside the existing raw-curl contract checks — verifying that the official CLI surfaces this distro's structured HTTP 501 (`feature_not_available_in_graalvm_native`) for both the DSL live debugger and runtime-rule roots, rather than crashing or reporting a confusing 404.
 
 ## 0.3.0
 

--- a/docs/version-mapping.md
+++ b/docs/version-mapping.md
@@ -8,7 +8,7 @@ Otherwise, it is shown as `{commit-id}-SNAPSHOT` indicating a development build 
 <!-- DOC-CHECK: version-mapping-table -->
 | Distro Version | Apache SkyWalking Version |
 |---|---|
-| 0.4.0-SNAPSHOT (dev) | `ad733554b027`-SNAPSHOT |
+| 0.4.0-SNAPSHOT (dev) | `89624809f078`-SNAPSHOT |
 | 0.3.0 | 10.4.0 |
 | 0.2.1 | `64a1795d8a58`-SNAPSHOT |
 | 0.2.0 | `64a1795d8a58`-SNAPSHOT |

--- a/test/e2e/cases/live-debugging/e2e.yaml
+++ b/test/e2e/cases/live-debugging/e2e.yaml
@@ -19,7 +19,10 @@
 # image cannot do. This distro pre-compiles all DSL at build time and serves a structured
 # HTTP 501 for those admin-server endpoints. This case verifies that contract.
 # Verify-only (no trigger): infra-e2e's trigger step aborts on a non-2xx response, so the
-# 501 is asserted through verify cases that curl the admin-server (port 17128) directly.
+# 501 is asserted through verify cases. Two complementary views: raw curl against the
+# admin-server (port 17128) pins the exact HTTP-contract body, while `swctl admin ...`
+# checks that the upstream admin-capable CLI (#13889) surfaces the same 501 cleanly to
+# end users instead of crashing or reporting a confusing 404.
 
 setup:
   env: compose
@@ -29,6 +32,8 @@ setup:
   steps:
     - name: set PATH
       command: export PATH=/tmp/skywalking-infra-e2e/bin:$PATH
+    - name: install swctl
+      command: bash skywalking/test/e2e-v2/script/prepare/setup-e2e-shell/install.sh swctl
 
 verify:
   retry:

--- a/test/e2e/cases/live-debugging/expected/swctl-dsl-debugging-501.yml
+++ b/test/e2e/cases/live-debugging/expected/swctl-dsl-debugging-501.yml
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# `swctl admin dsl-debug ...` against this distro: the official CLI surfaces the
+# stub's HTTP 501 (feature_not_available_in_graalvm_native) for the dsl-debugging root.
+httpStatus: 501
+error: feature_not_available_in_graalvm_native
+feature: dsl-debugging

--- a/test/e2e/cases/live-debugging/expected/swctl-runtime-rule-501.yml
+++ b/test/e2e/cases/live-debugging/expected/swctl-runtime-rule-501.yml
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# `swctl admin runtime-rule list` / `admin oal files` against this distro: the official
+# CLI surfaces the stub's HTTP 501 (feature_not_available_in_graalvm_native) for the
+# runtime-rule root.
+httpStatus: 501
+error: feature_not_available_in_graalvm_native
+feature: runtime-rule

--- a/test/e2e/cases/live-debugging/live-debugging-cases.yaml
+++ b/test/e2e/cases/live-debugging/live-debugging-cases.yaml
@@ -41,3 +41,49 @@ cases:
     expected: expected/http-status-501.yml
   - query: "echo httpStatus: $(curl -s -o /dev/null -w '%{http_code}' http://${oap_host}:${oap_17128}/runtime/rule/list)"
     expected: expected/http-status-501.yml
+
+  # --- Same 501 contract, now seen through the official `swctl admin` CLI ----------------
+  # Upstream #13889 moved the e2e admin-API calls from raw curl to the `swctl admin ...`
+  # command tree (SW_CTL_COMMIT bumped to the admin-capable build). Those same commands run
+  # against this distro must degrade cleanly: the stub returns HTTP 501, so swctl exits
+  # non-zero and logs its typed error envelope ("admin API <url>: HTTP 501: <body>") — the
+  # distro's structured body rides along inside it. `2>&1 || true` captures the envelope;
+  # grep pulls the stable fields back out (httpStatus + error code + feature root), proving
+  # the CLI reports a clean "unsupported" rather than crashing or a confusing 404. The
+  # feature root is the first dsl-debugging/runtime-rule token in the envelope (the path for
+  # dsl-debug, the feature field for runtime-rule — both resolve to the correct root).
+  - query: |
+      out=$(swctl --display json --admin-url=http://${oap_host}:${oap_17128} admin dsl-debug status 2>&1 || true)
+      printf 'httpStatus: %s\nerror: %s\nfeature: %s\n' \
+        "$(echo "$out" | grep -oE 'HTTP [0-9]+' | grep -oE '[0-9]+' | head -1)" \
+        "$(echo "$out" | grep -oE 'feature_not_available_in_graalvm_native' | head -1)" \
+        "$(echo "$out" | grep -oE 'dsl-debugging|runtime-rule' | head -1)"
+    expected: expected/swctl-dsl-debugging-501.yml
+  - query: |
+      out=$(swctl --display json --admin-url=http://${oap_host}:${oap_17128} admin dsl-debug sessions 2>&1 || true)
+      printf 'httpStatus: %s\nerror: %s\nfeature: %s\n' \
+        "$(echo "$out" | grep -oE 'HTTP [0-9]+' | grep -oE '[0-9]+' | head -1)" \
+        "$(echo "$out" | grep -oE 'feature_not_available_in_graalvm_native' | head -1)" \
+        "$(echo "$out" | grep -oE 'dsl-debugging|runtime-rule' | head -1)"
+    expected: expected/swctl-dsl-debugging-501.yml
+  - query: |
+      out=$(swctl --display json --admin-url=http://${oap_host}:${oap_17128} admin dsl-debug session start --catalog otel-rules --name vm --rule-name vm_memory_used 2>&1 || true)
+      printf 'httpStatus: %s\nerror: %s\nfeature: %s\n' \
+        "$(echo "$out" | grep -oE 'HTTP [0-9]+' | grep -oE '[0-9]+' | head -1)" \
+        "$(echo "$out" | grep -oE 'feature_not_available_in_graalvm_native' | head -1)" \
+        "$(echo "$out" | grep -oE 'dsl-debugging|runtime-rule' | head -1)"
+    expected: expected/swctl-dsl-debugging-501.yml
+  - query: |
+      out=$(swctl --display json --admin-url=http://${oap_host}:${oap_17128} admin runtime-rule list 2>&1 || true)
+      printf 'httpStatus: %s\nerror: %s\nfeature: %s\n' \
+        "$(echo "$out" | grep -oE 'HTTP [0-9]+' | grep -oE '[0-9]+' | head -1)" \
+        "$(echo "$out" | grep -oE 'feature_not_available_in_graalvm_native' | head -1)" \
+        "$(echo "$out" | grep -oE 'dsl-debugging|runtime-rule' | head -1)"
+    expected: expected/swctl-runtime-rule-501.yml
+  - query: |
+      out=$(swctl --display json --admin-url=http://${oap_host}:${oap_17128} admin oal files 2>&1 || true)
+      printf 'httpStatus: %s\nerror: %s\nfeature: %s\n' \
+        "$(echo "$out" | grep -oE 'HTTP [0-9]+' | grep -oE '[0-9]+' | head -1)" \
+        "$(echo "$out" | grep -oE 'feature_not_available_in_graalvm_native' | head -1)" \
+        "$(echo "$out" | grep -oE 'dsl-debugging|runtime-rule' | head -1)"
+    expected: expected/swctl-runtime-rule-501.yml

--- a/test/e2e/script/env
+++ b/test/e2e/script/env
@@ -17,11 +17,11 @@
 # Update when syncing the skywalking submodule.
 SW_AGENT_JAVA_COMMIT=ac0df43d7140e726eba9e5e5b1b75cf364c71dff
 SW_BANYANDB_COMMIT=84b919efca3fee3d51df9e97a734a9f10ae6f1d2
-SW_CTL_COMMIT=9a1beab08413ce415a00a8547a238a14691c5655
+SW_CTL_COMMIT=b447211a9319eeb29a445335e9c2536f8c1aa23d
 SW_KUBERNETES_COMMIT_SHA=da0e267f877b9b8e5f7728ae4ea7dc7723a2a073
 
 # UI image pin for the istio-als e2e test (ghcr.io/apache/skywalking/ui:<sha>).
-# NOT bumped to the synced submodule commit ad733554b0: 11.0.0 dropped the bundled UI,
+# NOT bumped to the synced submodule commit 89624809f0: 11.0.0 dropped the bundled UI,
 # so ghcr.io/apache/skywalking/ui is no longer published at recent commits. Kept at the
 # last commit whose UI image exists. The pins below track the sync.
 SW_UPSTREAM_COMMIT=f79451d3de23edb15277f5b6e315dc6779e73e1f


### PR DESCRIPTION
### Sync upstream to `89624809f0` and adopt the upstream swctl `admin` e2e migration

Advances the `skywalking/` submodule `ad733554b0` → `89624809f0` (4 commits — docs + e2e only, **no production code**). The notable upstream change is **#13889**, which migrated the e2e admin-API calls from raw `curl` to the new `swctl admin ...` command tree and bumped `skywalking-cli` to an admin-capable build. This PR brings that into the distro.

#### What changed
- **`SW_CTL_COMMIT`** `9a1beab0` → `b447211a` (admin-capable swctl) in `test/e2e/script/env`. Backward-compatible: the existing `metrics exec` / `service ls` / … commands used by the other reused e2e cases are unchanged; the `admin` command tree is purely additive (verified against the built binary).
- **`live-debugging` e2e** now drives the admin checks through `swctl admin dsl-debug` / `runtime-rule` / `oal` *alongside* the existing raw-curl HTTP-contract cases. This distro serves a structured **HTTP 501** for `/dsl-debugging/*` and `/runtime/*` (a closed-world native image can't do runtime MAL/LAL/OAL codegen), so swctl exits non-zero and logs its typed error envelope; the new cases grep back `httpStatus` + `error` code + `feature` root, proving the official CLI surfaces a clean *"unsupported"* (`feature_not_available_in_graalvm_native`) instead of crashing or a confusing 404. The case setup now installs swctl.
- Docs: `version-mapping.md` dev row + `changes/changes.md`.

#### Verification
- [x] `make compile` — BUILD SUCCESS
- [x] `license-eye header check` — 0 invalid
- [x] `verify-version-mapping.sh` — all mappings verified
- [x] swctl `b447211` output empirically validated against a mock of the distro's 501 stub: all five `admin` commands resolve to the expected `httpStatus: 501` / `error` / `feature`
- [ ] CI: unit tests, native amd64/arm64, e2e (incl. `live-debugging`)